### PR TITLE
c api: fix allocation warning

### DIFF
--- a/ext/tree_sitter/node.c
+++ b/ext/tree_sitter/node.c
@@ -263,6 +263,8 @@ static VALUE node_eq(VALUE self, VALUE other) {
 void init_node(void) {
   cNode = rb_define_class_under(mTreeSitter, "Node", rb_cObject);
 
+  rb_undef_alloc_func(cNode);
+
   /* Class methods */
   rb_define_method(cNode, "type", node_type, 0);
   rb_define_method(cNode, "symbol", node_symbol, 0);

--- a/ext/tree_sitter/tree.c
+++ b/ext/tree_sitter/tree.c
@@ -128,6 +128,8 @@ static VALUE tree_finalizer(VALUE _self) {
 void init_tree(void) {
   cTree = rb_define_class_under(mTreeSitter, "Tree", rb_cObject);
 
+  rb_undef_alloc_func(cTree);
+
   /* Class methods */
   rb_define_method(cTree, "copy", tree_copy, 0);
   rb_define_method(cTree, "root_node", tree_root_node, 0);


### PR DESCRIPTION
ruby 3.2 introduced a new warning when `rb_define_alloc_func` is not used. e.g.:

    warning: undefining the allocator of T_DATA class TreeSitter::Tree

When we don't allocate a class, we need to undefine it manually using `rb_undef_alloc_func`.