### PR TITLE
Minor corrections in tests

### DIFF
--- a/test/tree_sitter/language_test.rb
+++ b/test/tree_sitter/language_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative '../test_helper.rb'
+require_relative '../test_helper'
 
 ruby = TreeSitter.lang('ruby')
 parser = TreeSitter::Parser.new
@@ -8,7 +8,7 @@ parser.language = ruby
 
 program = <<~RUBY
   def mul(a, b)
-    res = a* b
+    res = a * b
     puts res.inspect
     return res
   end

--- a/test/tree_sitter/logger_test.rb
+++ b/test/tree_sitter/logger_test.rb
@@ -15,6 +15,16 @@ program = <<~RUBY
   end
 RUBY
 
+# Use with fork.
+#
+# Minitest on ruby 2.7 was failing sometimes for no particular reason,
+# complaining about some random number not having a `write` method.
+#
+# My assumption is that the global var $stderr is not playing nice when
+# we try to replace it and other minitest stuff are going alongside.
+#
+# If this theory holds, then forking should solve any race conditions that
+# minitest could introduce. Let's wait and see.
 def capture_stderr
   # The output stream must be an IO-like object. In this case we capture it in
   # an in-memory IO object so we can return the string value. You can assign any
@@ -30,12 +40,14 @@ end
 
 describe 'logging' do
   it 'should log to stderr by default' do
-    captured_output = capture_stderr do
-      # Does not output anything directly.
-      parser.logger = TreeSitter::Logger.new
-      parser.parse_string(nil, program)
+    fork do
+      captured_output = capture_stderr do
+        # Does not output anything directly.
+        parser.logger = TreeSitter::Logger.new
+        parser.parse_string(nil, program)
+      end
+      refute_equal 0, captured_output.length
     end
-    refute_equal 0, captured_output.length
   end
 
   it 'should log to IO objects' do

--- a/test/tree_sitter/logger_test.rb
+++ b/test/tree_sitter/logger_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require_relative '../test_helper.rb'
-require "stringio"
+require_relative '../test_helper'
+require 'stringio'
 
 ruby = TreeSitter.lang('ruby')
 parser = TreeSitter::Parser.new
@@ -9,7 +9,7 @@ parser.language = ruby
 
 program = <<~RUBY
   def mul(a, b)
-    res = a* b
+    res = a * b
     puts res.inspect
     return res
   end
@@ -19,7 +19,8 @@ def capture_stderr
   # The output stream must be an IO-like object. In this case we capture it in
   # an in-memory IO object so we can return the string value. You can assign any
   # IO object here.
-  previous_stderr, $stderr = $stderr, StringIO.new
+  previous_stderr = $stderr
+  $stderr = StringIO.new
   yield
   $stderr.string
 ensure
@@ -50,7 +51,7 @@ describe 'logging' do
     parser.logger = TreeSitter::Logger.new(backend, "%s#{delim}%s")
     parser.parse_string(nil, program)
     backend.each_line do |l|
-      assert (/#{delim}/) =~ l, 'delimiter must be in every single line'
+      assert (/#{delim}/ =~ l), 'delimiter must be in every single line'
     end
   end
 end

--- a/test/tree_sitter/node_test.rb
+++ b/test/tree_sitter/node_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative '../test_helper.rb'
+require_relative '../test_helper'
 
 ruby = TreeSitter.lang('ruby')
 parser = TreeSitter::Parser.new
@@ -8,7 +8,7 @@ parser.language = ruby
 
 program = <<~RUBY
   def mul(a, b)
-    res = a* b
+    res = a * b
     puts res.inspect
     return res
   end

--- a/test/tree_sitter/parser_test.rb
+++ b/test/tree_sitter/parser_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative '../test_helper.rb'
+require_relative '../test_helper'
 
 ruby = TreeSitter.lang('ruby')
 parser = TreeSitter::Parser.new
@@ -8,7 +8,7 @@ parser.language = ruby
 
 program = <<~RUBY
   def mul(a, b)
-    res = a* b
+    res = a * b
     puts res.inspect
     return res
   end
@@ -30,7 +30,7 @@ RUBY
 #                      | otherwise = fib' b (a+b) (n-1)
 # YBUR
 
-program_16 = program.encode('utf-16')
+program16 = program.encode('utf-16')
 # margorp_16 = margorp.encode('utf-16')
 
 describe 'loading a language' do
@@ -87,7 +87,7 @@ describe 'parse_string_encoding' do
     ['valid', program, 1, :utf8],
     # ['invalid', margorp, 3, :utf8],
     ['empty', ''.encode('utf-16'), 0, :utf16],
-    ['valid', program_16, 1, :utf16],
+    ['valid', program16, 1, :utf16],
     # ['invalid', margorp_16, 1, :utf16]
   ].each do |q, p, c, e|
     it "must parse #{q} programs in #{e}" do

--- a/test/tree_sitter/query_test.rb
+++ b/test/tree_sitter/query_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative '../test_helper.rb'
+require_relative '../test_helper'
 
 ruby = TreeSitter.lang('ruby')
 parser = TreeSitter::Parser.new
@@ -8,7 +8,7 @@ parser.language = ruby
 
 program = <<~RUBY
   def mul(a, b)
-    res = a* b
+    res = a * b
     puts res.inspect
     return res
   end
@@ -56,28 +56,28 @@ describe 'pattern/capture/string' do
   it 'must return an array of predicates for a pattern' do
     query = TreeSitter::Query.new(ruby, combined)
 
-    preds_0 = query.predicates_for_pattern(0)
-    assert_instance_of Array, preds_0
-    assert_equal 0, preds_0.size
+    preds0 = query.predicates_for_pattern(0)
+    assert_instance_of Array, preds0
+    assert_equal 0, preds0.size
 
-    preds_1 = query.predicates_for_pattern(1)
-    assert_instance_of Array, preds_1
-    assert_equal 0, preds_1.size
+    preds1 = query.predicates_for_pattern(1)
+    assert_instance_of Array, preds1
+    assert_equal 0, preds1.size
 
     query = TreeSitter::Query.new(ruby, predicate)
-    preds_2 = query.predicates_for_pattern(0)
-    assert_instance_of Array, preds_2
-    assert_equal 4, preds_2.size
+    preds2 = query.predicates_for_pattern(0)
+    assert_instance_of Array, preds2
+    assert_equal 4, preds2.size
   end
 
   it 'must return string names, quanitfier, and string value for capture id' do
     query = TreeSitter::Query.new(ruby, predicate)
     query.predicates_for_pattern(0).each do |step|
-      if TreeSitter::QueryPredicateStep::CAPTURE == step.type
-        assert_equal 'args', query.capture_name_for_id(step.value_id)
-        assert_equal TreeSitter::Quantifier::ONE_OR_MORE, query.capture_quantifier_for_id(0, step.value_id)
-        assert_equal 'match?', query.string_value_for_id(step.value_id)
-      end
+      next if step.type != TreeSitter::QueryPredicateStep::CAPTURE
+
+      assert_equal 'args', query.capture_name_for_id(step.value_id)
+      assert_equal TreeSitter::Quantifier::ONE_OR_MORE, query.capture_quantifier_for_id(0, step.value_id)
+      assert_equal 'match?', query.string_value_for_id(step.value_id)
     end
   end
 

--- a/test/tree_sitter/tree_cursor_test.rb
+++ b/test/tree_sitter/tree_cursor_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative '../test_helper.rb'
+require_relative '../test_helper'
 
 ruby = TreeSitter.lang('ruby')
 parser = TreeSitter::Parser.new
@@ -8,7 +8,7 @@ parser.language = ruby
 
 program = <<~RUBY
   def mul(a, b)
-    res = a* b
+    res = a * b
     puts res.inspect
     return res
   end


### PR DESCRIPTION
This PR is created specifically for a recurrent failure on ruby 2.7+macOS.

It seems like some race condition is happening with minitest, screwing $stderr.
We need this test because logging defaults to $stderr (by us, not tree-sitter), and we want to make sure that this invariant holds at all times.