### PR TITLE
Publish gem artifacts on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,29 @@
+name: "Publish Gem"
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish_gem:
+    name: Publish to Rubygems
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Fetch Github Release Asset
+        uses: dsaltares/fetch-gh-release-asset@1.1.0
+        with:
+          file: tree_sitter.*.gem
+          regex: true
+          target: pkg/
+
+      - name: Extract & Display structure of built gems
+        run: ls -l pkg/
+
+      - name: Release Gem
+        uses: cadwallion/publish-rubygems-action@master
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          RUBYGEMS_API_KEY: ${{secrets.RUBYGEMS_API_KEY}}
+          RELEASE_COMMAND: bin/publish
+

--- a/bin/publish
+++ b/bin/publish
@@ -1,23 +1,7 @@
 #! /usr/bin/env sh
 set -e
 
-bundle exec rake test
-
-TS_VERSION=`ruby -e "require './lib/tree_sitter/version' ; puts TreeSitter::VERSION"`
-echo "Releasing tree_sitter-v$TS_VERSION"
-
-gem build tree_sitter.gemspec
-
-while true; do
-    read -p "Publish to Rubygems? " yn
-    case $yn in
-        [Yy]* )
-             gem push tree_sitter-$TS_VERSION.gem
-             echo "Creating git tag"
-             git tag "v$TS_VERSION"
-             git push origin "v$TS_VERSION"
-             break;;
-        [Nn]* ) break;;
-        * ) echo "y or n?";;
-    esac
+find pkg -name "*.gem" | while read packaged_gem ; do
+  echo "Publishing $packaged_gem"
+  gem push "$packaged_gem"
 done


### PR DESCRIPTION
## What

Follow-up to #18. This PR doesn't change how the artifacts are built but instead adds a new Github Action to publish the artifacts when a new release is published.

## Publishing

I tested this PR against a copy of this repo here: https://github.com/DerekStride/test-rb-ts-bindings

The logs for the new workflow are here: https://github.com/DerekStride/test-rb-ts-bindings/actions/runs/3877336119/jobs/6612235477

It fails because I never set the RubyGems API Key, instructions on how to do that are below.

```
Running gem release task...
+ release_command=bin/publish
+ exec bin/publish
Publishing pkg/tree_sitter-0.20.6.1-mri-2.7.gem
Enter your RubyGems.org credentials.
Don't have an account yet? Create one at https://rubygems.org/sign_up

---
error: Invalid credentials
code: 401
```

## Dependencies

I used the [Fetch Github Release Asset](https://github.com/marketplace/actions/fetch-github-release-asset) action to grab all the gem artifacts from the release.

I used the [Publish to Rubygems](https://github.com/marketplace/actions/publish-to-rubygems) action to manage pushing the gem artifacts to rubygems. This will require you to set `RUBYGEMS_API_KEY` in this repositories `Settings > Secrets > Actions`. You can get a key from rubygems in `Settings > API KEYS > New API Key`.
