### PR TITLE
Only publish unique gem versions

### DIFF
--- a/bin/publish
+++ b/bin/publish
@@ -1,7 +1,7 @@
 #! /usr/bin/env sh
 set -e
 
-find pkg -name "*.gem" | while read packaged_gem ; do
+find pkg -name "*.gem" | grep "ruby_tree_sitter.*mri-3.2" | while read packaged_gem ; do
   echo "Publishing $packaged_gem"
   gem push "$packaged_gem"
 done


### PR DESCRIPTION
## What

fixes https://github.com/Faveod/ruby-tree-sitter/issues/23#issuecomment-1426757155

The [failed publish build](https://github.com/Faveod/ruby-tree-sitter/actions/runs/4151349566/jobs/7181605454) was a result of attempting to publish equivalent gem packages. Digging in a bit there were two successful pushes then a failure.

**Success 1**

```
Publishing pkg/ruby_tree_sitter-0.20.6.3-mri-2.7.gem
Pushing gem to https://rubygems.org.../
Successfully registered gem: ruby_tree_sitter (0.20.6.3)
```

**Success 2**

```
Publishing pkg/ruby_tree_sitter-0.20.6.3-x86_64-darwin-19-mri-2.7.gem
Pushing gem to https://rubygems.org.../
Successfully registered gem: ruby_tree_sitter (0.20.6.3-x86_64-darwin-19)
```

**Failure**

```
Publishing pkg/ruby_tree_sitter-0.20.6.3-mri-3.gem
Pushing gem to https://rubygems.org.../
Repushing of gem versions is not allowed.
```

What's happening is that there are no differences between the gem packages based on the version of ruby the gem was built with. The only difference is whether there was a pre-compiled bundle for a platform.

## Solution

I believe filtering out gem packages to only push unique platforms should fix the issue. This PR updates the publish script to only load the packaged gems that were built with ruby 3.2.

## Testing it out

I created files with the same name as the gems from the [failed build](https://github.com/Faveod/ruby-tree-sitter/actions/runs/4151349566/jobs/7181605454) and tested to make sure only unique gem builds would be pushed.

```
➜ ruby-tree-sitter l -l pkg
.rw-r--r-- 0 derek ruby_tree_sitter-0.20.6.3-mri-2.7.gem
.rw-r--r-- 0 derek ruby_tree_sitter-0.20.6.3-mri-3.1.gem
.rw-r--r-- 0 derek ruby_tree_sitter-0.20.6.3-mri-3.2.gem
.rw-r--r-- 0 derek ruby_tree_sitter-0.20.6.3-mri-3.gem
.rw-r--r-- 0 derek ruby_tree_sitter-0.20.6.3-x86_64-darwin-19-mri-2.7.gem
.rw-r--r-- 0 derek ruby_tree_sitter-0.20.6.3-x86_64-darwin-19-mri-3.1.gem
.rw-r--r-- 0 derek ruby_tree_sitter-0.20.6.3-x86_64-darwin-19-mri-3.2.gem
.rw-r--r-- 0 derek ruby_tree_sitter-0.20.6.3-x86_64-darwin-19-mri-3.gem
.rw-r--r-- 0 derek ruby_tree_sitter-0.20.6.3-x86_64-linux-mri-2.7.gem
.rw-r--r-- 0 derek ruby_tree_sitter-0.20.6.3-x86_64-linux-mri-3.1.gem
.rw-r--r-- 0 derek ruby_tree_sitter-0.20.6.3-x86_64-linux-mri-3.2.gem
.rw-r--r-- 0 derek ruby_tree_sitter-0.20.6.3-x86_64-linux-mri-3.gem
.rw-r--r-- 0 derek ruby_tree_sitter-0.20.6.3.gem
.rw-r--r-- 0 derek tree_sitter-0.20.6.1-mri-2.7.gem
.rw-r--r-- 0 derek tree_sitter-0.20.6.1-mri-3.1.gem
.rw-r--r-- 0 derek tree_sitter-0.20.6.1-mri-3.2.gem
.rw-r--r-- 0 derek tree_sitter-0.20.6.1-mri-3.gem
.rw-r--r-- 0 derek tree_sitter-0.20.6.1-x86_64-darwin-19-mri-2.7.gem
.rw-r--r-- 0 derek tree_sitter-0.20.6.1-x86_64-darwin-19-mri-3.1.gem
.rw-r--r-- 0 derek tree_sitter-0.20.6.1-x86_64-darwin-19-mri-3.2.gem
.rw-r--r-- 0 derek tree_sitter-0.20.6.1-x86_64-darwin-19-mri-3.gem
.rw-r--r-- 0 derek tree_sitter-0.20.6.1-x86_64-linux-mri-2.7.gem
.rw-r--r-- 0 derek tree_sitter-0.20.6.1-x86_64-linux-mri-3.1.gem
.rw-r--r-- 0 derek tree_sitter-0.20.6.1-x86_64-linux-mri-3.2.gem
.rw-r--r-- 0 derek tree_sitter-0.20.6.1-x86_64-linux-mri-3.gem
.rw-r--r-- 0 derek tree_sitter-0.20.6.1.gem
```

```
➜ ruby-tree-sitter bin/publish
Publishing pkg/ruby_tree_sitter-0.20.6.3-mri-3.2.gem
Publishing pkg/ruby_tree_sitter-0.20.6.3-x86_64-darwin-19-mri-3.2.gem
Publishing pkg/ruby_tree_sitter-0.20.6.3-x86_64-linux-mri-3.2.gem
```