### PR TITLE
Support static linking when `--disable-sys-libs`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,11 +1,13 @@
-AllCops:
-  TargetRubyVersion: "2.7"
-  Exclude:
-    - tree-sitter-parsers/**/*
-    - tmp/**/*
-  NewCops: enable
+Metrics/AbcSize:
+  Max: 29
 
-Style/IfUnlessModifier:
-  Enabled: false
+Metrics/MethodLength:
+  Max: 29
+
+Style/GlobalVars:
+  Exclude:
+    - ext/tree_sitter/extconf.rb
+
+# `unless` is cool and all, but I'd rather not. Less confusion.
 Style/NegatedIf:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,4 @@ gemspec
 
 gem 'rubocop', require: false
 
-gem "ruby-lsp", "~> 0.3.2", :group => :development
+gem 'ruby-lsp', require: false

--- a/Rakefile
+++ b/Rakefile
@@ -11,14 +11,15 @@ rescue LoadError
   ERROR
 end
 
-require "ruby_memcheck"
+require 'ruby_memcheck'
 
 gemspec = Gem::Specification.load('tree_sitter.gemspec')
 
 cross_rubies = [
+  '3.2.0',
   '3.1.0',
   '3.0.0',
-  '2.7.0',
+  '2.7.0'
 ].freeze
 
 cross_platforms = [
@@ -30,21 +31,21 @@ cross_platforms = [
   #
   # FIXME: ld: unknown -soname
   # that's a bug in tree-sitter's makefile: it only checks for OS type and
-  # not compiler type, so when we're cross-building it blows in out face
+  # not compiler type, so when we're cross-building it blows in our face
   #
   'x86_64-darwin',
-  'arm64-darwin',
+  'arm64-darwin'
 ].freeze
 
 ENV['RUBY_CC_VERSION'] = cross_rubies.join(':') if !ENV['RUBY_CC_VERSION']
 Rake::ExtensionTask.new('tree_sitter', gemspec) do |r|
   r.lib_dir = 'lib/tree_sitter'
-    require "rake_compiler_dock"
-    r.cross_compile = true
-    r.cross_platform = cross_platforms
-    r.cross_compiling do |spec|
-      spec.files.reject! { |file| /(\.gz)$|(\.zip)$|(\.tar)$/ =~ File.basename(file) }
-    end
+  require 'rake_compiler_dock'
+  r.cross_compile = true
+  r.cross_platform = cross_platforms
+  r.cross_compiling do |spec|
+    spec.files.reject! { |file| /(\.gz)$|(\.zip)$|(\.tar)$/ =~ File.basename(file) }
+  end
 end
 
 Gem::PackageTask.new(gemspec) do |pkg|

--- a/ext/tree_sitter/extconf.rb
+++ b/ext/tree_sitter/extconf.rb
@@ -38,23 +38,31 @@ end
 #          Downloaded libs           #
 # ################################## #
 
+# This library's version is not really in semver.
+#
+# We append a version next to the tree-sitter's, so when fetching from sources
+# we need to strip off the addition.
+version = TreeSitter::VERSION.gsub(/\A(\d+\.\d+\.\d+)(\.\d+)?\z/, '\1')
+
 dir_include, dir_lib =
   if system_tree_sitter?
-    [['/opt/include', '/opt/local/include', '/usr/include', '/usr/local/include'],
-     ['/opt/lib', '/opt/local/lib', '/usr/lib', '/usr/local/lib']]
+    [
+      %w[/opt/include /opt/local/include /usr/include /usr/local/include],
+      %w[/opt/lib /opt/local/lib /usr/lib /usr/local/lib]
+    ]
   else
-    src = Pathname.pwd / "tree-sitter-#{TreeSitter::VERSION}"
+    src = Pathname.pwd / "tree-sitter-#{version}"
     if !Dir.exist? src
       if find_executable('git')
         sh "git clone https://github.com/tree-sitter/tree-sitter #{src}"
-        sh "cd #{src} && git checkout tags/v#{TreeSitter::VERSION}"
+        sh "cd #{src} && git checkout tags/v#{version}"
       elsif find_executable('curl')
         if find_executable('tar')
-          sh "curl -L https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v#{TreeSitter::VERSION}.tar.gz -o tree-sitter-v#{TreeSitter::VERSION}.tar.gz"
-          sh "tar -xf tree-sitter-v#{TreeSitter::VERSION}.tar.gz"
+          sh "curl -L https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v#{version}.tar.gz -o tree-sitter-v#{version}.tar.gz"
+          sh "tar -xf tree-sitter-v#{version}.tar.gz"
         elsif find_executable('zip')
-          sh "curl -L https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v#{TreeSitter::VERSION}.zip -o tree-sitter-v#{TreeSitter::VERSION}.zip"
-          sh "unzip -q tree-sitter-v#{TreeSitter::VERSION}.zip"
+          sh "curl -L https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v#{version}.zip -o tree-sitter-v#{version}.zip"
+          sh "unzip -q tree-sitter-v#{version}.zip"
         else
           abort('Could not find `tar` or `zip` (and `git` was not found!)')
         end

--- a/ext/tree_sitter/repo.rb
+++ b/ext/tree_sitter/repo.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require_relative '../../lib/tree_sitter/version'
+
+module TreeSitter
+  # Fetches tree-sitter sources.
+  class Repo
+    attr_reader :exe, :src, :url, :version
+
+    def initialize
+      # This library's version is not really in semver.
+      #
+      # We append a version next to the tree-sitter's, so when fetching from sources
+      # we need to strip off the addition. And that's the default behavior.
+      @version = TreeSitter::VERSION.gsub(/\A(\d+\.\d+\.\d+)(\.\d+)?\z/, '\1')
+
+      # `tree-sitter-@version` is the name produced by tagged releases of sources
+      # by git, so we use it everywhere, including when cloning from git.
+      @src = Pathname.pwd / "tree-sitter-#{@version}"
+
+      @url = {
+        git: 'https://github.com/tree-sitter/tree-sitter',
+        tar: "https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v#{@version}.tar.gz",
+        zip: "https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v#{@version}.zip"
+      }
+
+      @exe = {}
+      %i[curl git tar wget zip].each do |cmd|
+        @exe[cmd] = find_executable(cmd.to_s)
+      end
+    end
+
+    def compile
+      # We need to clean because the same folder is used over and over
+      # by rake-compiler-dock
+      sh "cd #{src} && make clean && make"
+    end
+
+    def exe?(name)
+      @exe[name]
+    end
+
+    def extract?
+      !exe.filter { |k, v| %i[tar zip].include?(k) && v }.empty?
+    end
+
+    def download
+      # TODO: should we force re-download? Maybe with a flag?
+      return true if Dir.exist? src
+
+      res = false
+      %w[git curl wget].each do |cmd|
+        res =
+          if find_executable(cmd)
+            send("sources_from_#{cmd}")
+          else
+            false
+          end
+        break if res
+      end
+
+      res
+    end
+
+    def include_and_lib_dirs
+      [[src / 'lib' / 'include'], [src.to_s]]
+    end
+
+    def keep_static_lib
+      src
+        .children
+        .filter { |f| /\.(dylib|so)/ =~ f.basename.to_s }
+        .each(&:unlink)
+    end
+
+    def sh(cmd)
+      return if system(cmd)
+
+      abort <<~MSG
+
+        Failed to run: #{cmd}
+
+        exiting …
+
+      MSG
+    end
+
+    def sources_from_curl
+      return false if !exe?(:curl) || !extract?
+
+      if exe?(:tar)
+        sh "curl -L #{url[:tar]} -o tree-sitter-v#{version}.tar.gz"
+        sh "tar -xf tree-sitter-v#{version}.tar.gz"
+      elsif exe?(:zip)
+        sh "curl -L #{url[:zip]} -o tree-sitter-v#{version}.zip"
+        sh "unzip -q tree-sitter-v#{version}.zip"
+      end
+
+      true
+    end
+
+    def sources_from_git
+      return false if !exe?(:git)
+
+      sh "git clone #{url[:git]} #{src}"
+      sh "cd #{src} && git checkout tags/v#{version}"
+
+      true
+    end
+
+    def sources_from_wget
+      return false if !exe?(:wget) || !extract?
+
+      if exe?(:tar)
+        sh "wget #{url[:tar]} -O tree-sitter-v#{version}.tar.gz"
+        sh "tar -xf tree-sitter-v#{version}.tar.gz"
+      elsif exe?(:zip)
+        sh "wget #{url[:zip]} -O tree-sitter-v#{version}.zip"
+        sh "unzip -q tree-sitter-v#{version}.zip"
+      end
+
+      true
+    end
+  end
+end

--- a/ext/tree_sitter/repo.rb
+++ b/ext/tree_sitter/repo.rb
@@ -8,11 +8,7 @@ module TreeSitter
     attr_reader :exe, :src, :url, :version
 
     def initialize
-      # This library's version is not really in semver.
-      #
-      # We append a version next to the tree-sitter's, so when fetching from sources
-      # we need to strip off the addition. And that's the default behavior.
-      @version = TreeSitter::VERSION.gsub(/\A(\d+\.\d+\.\d+)(\.\d+)?\z/, '\1')
+      @version = TREESITTER_VERSION
 
       # `tree-sitter-@version` is the name produced by tagged releases of sources
       # by git, so we use it everywhere, including when cloning from git.

--- a/lib/tree_sitter/version.rb
+++ b/lib/tree_sitter/version.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 module TreeSitter
-  VERSION = '0.20.8.1'
+  TREESITTER_VERSION = '0.20.8'
+  VERSION = "#{TREESITTER_VERSION}.2".freeze
 end

--- a/tree_sitter.gemspec
+++ b/tree_sitter.gemspec
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 lib = File.expand_path('lib', __dir__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+$LOAD_PATH.unshift(lib) if !$LOAD_PATH.include?(lib)
 
 require 'tree_sitter/version'
 
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.version       = TreeSitter::VERSION
 
   spec.extensions    = %(ext/tree_sitter/extconf.rb)
-  spec.files         = %w(LICENSE README.md tree_sitter.gemspec)
+  spec.files         = %w[LICENSE README.md tree_sitter.gemspec]
   spec.files        += Dir.glob('ext/**/*.[ch]')
   spec.files        += Dir.glob('lib/**/*.rb')
   spec.test_files    = Dir.glob('test/**/*')


### PR DESCRIPTION
When using the gem with sys libs, we dynamically link against the system tree-sitter.
When using `--disable-sys-libs`, we statically link against the downloaded tree-sitter.