### PR TITLE
fix(gem): include `repo.rb` in gemspec files

### DIFF
--- a/tree_sitter.gemspec
+++ b/tree_sitter.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.extensions    = %(ext/tree_sitter/extconf.rb)
   spec.files         = %w[LICENSE README.md tree_sitter.gemspec]
-  spec.files        += Dir.glob('ext/**/*.[ch]')
+  spec.files        += Dir.glob('ext/**/*.{c,h,rb}')
   spec.files        += Dir.glob('lib/**/*.rb')
   spec.test_files    = Dir.glob('test/**/*')
 


### PR DESCRIPTION
## What

The `ext/tree_sitter/repo.rb` file isn't included in the files packaged with the gem.

```
extconf.rb:6:in `require_relative': cannot load such file --
/home/runner/work/tree_stand/tree_stand/vendor/bundle/ruby/3.1.0/gems/ruby_tree_sitter-0.20.8.2/ext/tree_sitter/repo
```

ref: https://github.com/Shopify/tree_stand/actions/runs/7173716654/job/19533672716

## Solution

The fix is fairly simple:

```
>> Dir.glob('ext/**/*.{c,h,rb}') - Dir.glob('ext/**/*.[ch]')                                                                                                                                                                              
=> ["ext/tree_sitter/repo.rb", "ext/tree_sitter/extconf.rb"]
```