### PR TITLE
chore: release v1.0.0

### DIFF
--- a/lib/tree_sitter/version.rb
+++ b/lib/tree_sitter/version.rb
@@ -4,5 +4,5 @@ module TreeSitter
   # The version of the tree-sitter library.
   TREESITTER_VERSION = '0.20.9'
   # The current version of the gem.
-  VERSION = "#{TREESITTER_VERSION}.3".freeze
+  VERSION = "1.0.0"
 end


### PR DESCRIPTION
## What

According to https://github.com/Faveod/ruby-tree-sitter/issues/37 I think the last thing to do is release v1.0 to mark the merger with [TreeStand](https://github.com/Shopify/tree_stand) as completed. After that I'll get the old repo marked as archived and update the README to point to this project.