### PR TITLE
fix(pretty-print): never pad by less than zero

### DIFF
--- a/lib/tree_stand/utils/printer.rb
+++ b/lib/tree_stand/utils/printer.rb
@@ -33,7 +33,7 @@ module TreeStand
             next
           end
 
-          io << "#{line.sexpr}#{' ' * (@ralign - line.sexpr.size)}| #{line.text}\n"
+          io << "#{line.sexpr}#{' ' * [(@ralign - line.sexpr.size), 0].max}| #{line.text}\n"
         end
 
         io


### PR DESCRIPTION
## What

```error
lib/tree_stand/utils/printer.rb:37:in `*': negative argument (ArgumentError)

          io << "#{line.sexpr}#{' ' * (@ralign - line.sexpr.size)}| #{line.text}\n"
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

We append closing parenthesis to close the last open node recursively. This can sometimes cause an overflow where `Line#sexpr` returns a string longer than the right aligned node text column.

https://github.com/Faveod/ruby-tree-sitter/blob/bae141002843e56544279b772dfd4775b92f6262/lib/tree_stand/utils/printer.rb#L68

This change makes sure that in those edge cases we don't raise an argument error.