### PR TITLE
TreeSand load improvement

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,6 +16,9 @@ Gemspec/RequireMFA:
 Layout/EndAlignment:
   EnforcedStyleAlignWith: variable
 
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
 Lint/UnusedMethodArgument:
   Enabled: false
 

--- a/.yardopts
+++ b/.yardopts
@@ -2,7 +2,5 @@
 --exclude ext/tree_sitter/.*
 -
 README.md
-docs/Development.md
-docs/Notes.md
-docs/SIGSEGV.md
 LICENSE
+docs/*

--- a/README.md
+++ b/README.md
@@ -69,8 +69,7 @@ This gem is a binding for `tree-sitter`. It doesn't have a version of
 
 You must install `tree-sitter` and make sure that their dynamic library is
 accessible from `$PATH`, or build the gem with `--disable-sys-libs`, which will
-download the latest tagged `tree-sitter` and build against it (see [Build from
-source](docs/Contributing.md#build-from-source) .)
+download the latest tagged `tree-sitter` and build against it (see [Build from source](docs/Contributing.md#build-from-source) .)
 
 You can either install `tree-sitter` from source or through your go-to package manager.
 
@@ -139,8 +138,7 @@ bundle config set build.ruby_tree_sitter --disable-sys-libs
 If you don't want to install from `rubygems`, `git`, or if you don't want to
 compile on install, then download a native gem from this repository's
 [releases](https://github.com/Faveod/ruby-tree-sitter/releases), or you can
-compile it yourself (see [Build from
-source](docs/Contributing.md#build-from-source) .)
+compile it yourself (see [Build from source](docs/Contributing.md#build-from-source) .)
 
 In that case, you'd have to point your `Gemfile` to the `gem` as such:
 
@@ -177,7 +175,7 @@ See `examples` directory.
 
 ## Development
 
-See [`docs/README.md`](docs/Contributing.md).
+See [`docs/Contributing.md`](docs/Contributing.md).
 
 ## 🚧 👷‍♀️ Notes 👷 🚧
 
@@ -192,7 +190,7 @@ don't copy them left and right, and then expect them to work without
 `SEGFAULT`ing and creating a black-hole in your living-room.  Assume that you
 have to work locally with them. If you get a `SEGFAULT`, you can debug the
 native `C` code using `gdb`.  You can read more on `SEGFAULT`s
-[here](docs/SIGSEGV.md), and debugging [here](docs/Contributing.md#Debugging).
+[here](docs/SIGSEGV.md), and debugging [here](docs/Contributing#Debugging.md).
 
 That said, we do aim at providing an idiomatic `Ruby` interface.  It should also
 provide a _safer_ interface, where you don't have to worry about when and how

--- a/bin/setup
+++ b/bin/setup
@@ -3,6 +3,21 @@ set -euo pipefail
 IFS=$'\n\t'
 set -vx
 
+# TODO: migrate this to bin/get
+
+case $OSTYPE in
+darwin*)
+	ext=dylib
+	CC=cc
+	CXX=c++
+	;;
+*)
+	ext=so
+	CC=gcc
+	CXX=g++
+	;;
+esac
+
 bundle install
 
 if [[ ! -d tmp/tree-sitter-math ]]; then
@@ -13,11 +28,11 @@ fi
 cd tmp/tree-sitter-math
 
 mkdir -p target
-gcc -shared -o target/parser.so -fPIC src/parser.c -I./src
+$CC -shared -o "target/parser.$ext" -fPIC src/parser.c -I./src
 
 cd ../..
 mkdir -p tree-sitter-parsers
-cp tmp/tree-sitter-math/target/parser.so tree-sitter-parsers/math.so
+cp "tmp/tree-sitter-math/target/parser.$ext" "tree-sitter-parsers/math.$ext"
 
 for lang in "$@"
 do

--- a/ext/tree_sitter/language.c
+++ b/ext/tree_sitter/language.c
@@ -32,7 +32,7 @@ VALUE new_language(const TSLanguage *language) {
  * with this gem.
  *
  * @param name [String] the parser's name.
- * @param path [String] the parser's shared library (so, dylib) path on disk.
+ * @param path [String, Pathname] the parser's shared library (so, dylib) path on disk.
  *
  * @return [Language]
  */

--- a/ext/tree_sitter/logger.c
+++ b/ext/tree_sitter/logger.c
@@ -154,9 +154,9 @@ static void logger_initialize_stderr(logger_t *logger) {
  *
  * You can provide your proper backend. You have to make sure that it
  * exposes a +printf+, +puts+, or +write+ (lookup is done in that specific
- * order). {StringIO} is a perfect candidate.
+ * order). {::StringIO} is a perfect candidate.
  *
- * You can also provide a format ({String}) if your backend supports a +printf+.
+ * You can also provide a format ({::String}) if your backend supports a +printf+.
  *
  * @example
  *   backend = StringIO.new

--- a/ext/tree_sitter/parser.c
+++ b/ext/tree_sitter/parser.c
@@ -208,7 +208,7 @@ static VALUE parser_set_logger(VALUE self, VALUE logger) {
  *    same arguments. Or you can start parsing from scratch by first calling
  *    {Parser#reset}.
  * 3. Parsing was cancelled using a cancellation flag that was set by an
- *    earlier call to {Parsert#cancellation_flag=}. You can resume parsing
+ *    earlier call to {Parser#cancellation_flag=}. You can resume parsing
  *    from where the parser left out by calling {Parser#parse} again with
  *    the same arguments.
  *

--- a/lib/tree_stand/config.rb
+++ b/lib/tree_stand/config.rb
@@ -1,13 +1,19 @@
 # frozen_string_literal: true
 # typed: true
 
+require 'pathname'
+
 module TreeStand
   # Global configuration for the gem.
   # @api private
   class Config
     extend T::Sig
 
-    sig { returns(String) }
-    attr_accessor :parser_path
+    sig { returns(T.nilable(Pathname)) }
+    attr_reader :parser_path
+
+    def parser_path=(path)
+      @parser_path = Pathname(path)
+    end
   end
 end

--- a/lib/tree_stand/parser.rb
+++ b/lib/tree_stand/parser.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 # typed: true
 
+require 'pathname'
+
 module TreeStand
   # Wrapper around the TreeSitter parser. It looks up the parser by filename in
   # the configured parsers directory.
@@ -14,6 +16,14 @@ module TreeStand
   #
   #   # Looks for a parser in `path/to/parser/folder/ruby.{so,dylib}`
   #   ruby_parser = TreeStand::Parser.new("ruby")
+  #
+  # If no {TreeStand::Config#parser_path} is setup, {TreeStand} will lookup in a
+  # set of default paths.  You can always override any configuration by passing
+  # the environment variable `TREE_SITTER_PARSERS` (colon-separated).
+  #
+  # @see language
+  # @see search_for_lib
+  # @see LIBDIRS
   class Parser
     extend T::Sig
 
@@ -23,14 +33,160 @@ module TreeStand
     sig { returns(TreeSitter::Parser) }
     attr_reader :ts_parser
 
+    # A colon-seprated list of paths pointing to directories that can contain parsers.
+    # Order matters.
+    # Takes precedence over default lookup paths.
+    ENV_PARSERS =
+      ENV['TREE_SITTER_PARSERS']
+        &.split(':')
+        &.map { |v| Pathname(v) }
+        .freeze
+
+    # The default paths we use to lookup parsers when no specific
+    # {TreeStand::Config#parser_path} is {nil}.
+    # Order matters.
+    LIBDIRS = [
+      'tree-sitter-parsers',
+      '/opt/local/lib',
+      '/opt/lib',
+      '/usr/local/lib',
+      '/usr/lib',
+    ].map { |p| Pathname(p) }.freeze
+
+    # The library directories we need to look into.
+    #
+    # @return [Array<Pathname>] the list of candidate places to use when searching for parsers.
+    #
+    # @see ENV_PARSERS
+    # @see LIBDIRS
+    sig { returns(T::Array[Pathname]) }
+    def self.lib_dirs = [
+      *ENV_PARSERS,
+      *(TreeStand.config.parser_path ? [TreeStand.config.parser_path] : LIBDIRS),
+    ].compact
+
+    # The platform-specific extension of the parser.
+    # @return [String] `dylib` or `so` for mac or linux.
+    sig { returns(String) }
+    def self.ext
+      case Gem::Platform.local.os
+      in   /darwin/ then 'dylib'
+      else               'so'
+      end
+    end
+
+    # Lookup a parser by name.
+    #
+    # Precedence:
+    # 1. `Env['TREE_SITTER_PARSERS]`
+    # 2. {TreeStand::Config#parser_path}
+    # 3. {LIBDIRS}
+    #
+    # If a {TreeStand::Config#parser_path} is `nil`, {LIBDIRS} is used.
+    # If a {TreeStand::Config#parser_path} is a {::Pathname}, {LIBDIRS} is ignored.
+    sig { params(name: String).returns(T.nilable(Pathname)) }
+    def self.search_for_lib(name)
+      files = [
+        name,
+        "tree-sitter-#{name}",
+        "libtree-sitter-#{name}",
+      ].map { |v| "#{v}.#{ext}" }
+
+      res = lib_dirs
+        .product(files)
+        .find do |dir, so|
+          path = dir / so
+          path = dir / name / so if !path.exist?
+          break path.expand_path if path.exist?
+        end
+      res.is_a?(Array) ? nil : res
+    end
+
+    # Generates a string message on where parser lookup happens.
+    #
+    # @return [String] A pretty message.
+    sig { returns(String) }
+    def self.search_lib_message
+      indent = 2
+      pretty = ->(arr) {
+        if arr
+          arr
+            .compact
+            .map { |v| "#{' ' * indent}#{v.expand_path}" }
+            .join("\n")
+        end
+      }
+      <<~MSG
+        From ENV['TREE_SITTER_PARSERS']:
+        #{pretty.call(ENV_PARSERS)}
+
+        From TreeStand.config.parser_path:
+        #{pretty.call([TreeStand.config.parser_path])}
+
+        From Defaults:
+        #{pretty.call(LIBDIRS)}
+      MSG
+    end
+
+    # Load a language from configuration or default lookup paths.
+    #
+    # @example Load java from default paths
+    #    # This will look for:
+    #    #
+    #    #   tree-sitter-parsers/(java/)?(libtree-sitter-)?java.{ext}
+    #    #   /opt/local/lib/(java/)?(libtree-sitter-)?java.{ext}
+    #    #   /opt/lib/(java/)?(libtree-sitter-)?java.{ext}
+    #    #   /usr/local/lib/(java/)?(libtree-sitter-)?java.{ext}
+    #    #   /usr/lib/(java/)?(libtree-sitter-)?java.{ext}
+    #    #
+    #    java = TreeStand::Parser.language('java')
+    #
+    # @example Load java from a configured path
+    #    # This will look for:
+    #    #
+    #    #   /my/path/(java/)?(libtree-sitter-)?java.{ext}
+    #    #
+    #    TreeStand.config.parser_path = '/my/path'
+    #    java = TreeStand::Parser.language('java')
+    #
+    # @example Load java from environment variables
+    #    # This will look for:
+    #    #
+    #    #   /my/forced/env/path/(java/)?(libtree-sitter-)?java.{ext}
+    #    #   /my/path/(java/)?(libtree-sitter-)?java.{ext}
+    #    #
+    #    # … and the same works for the default paths if `TreeStand.config.parser_path`
+    #    # was `nil`
+    #    ENV['TREE_SITTER_PARSERS'] = '/my/forced/env/path'
+    #    TreeStand.config.parser_path = '/my/path'
+    #    java = TreeStand::Parser.language('java')
+    #
+    # @param name [String] the name of the parser.
+    #   This name is used to load the symbol from the compiled parser, replacing `-` with `_`.
+    # @return [TreeSitter:language] a language object to use in your parsers.
+    # @raise [RuntimeError] if the parser was not found.
+    # @see search_for_lib
+    sig { params(name: String).returns(TreeSitter::Language) }
+    def self.language(name)
+      lib = search_for_lib(name)
+
+      if lib.nil?
+        raise <<~MSG
+          Failed to load a parser for #{name}.
+
+          #{search_lib_message}
+        MSG
+      end
+
+      # We know that the bindings will accept `lib`, but I don't know how to tell sorbet
+      # the types in ext/tree_sitter where `load` is defined.
+      TreeSitter::Language.load(name.gsub(/-/, '_'), T.unsafe(lib))
+    end
+
     # @param language [String]
     sig { params(language: String).void }
     def initialize(language)
-      @language_string = language
-      @ts_language = TreeSitter::Language.load(
-        language,
-        "#{TreeStand.config.parser_path}/#{language}.so",
-      )
+      @ts_language = Parser.language(language)
       @ts_parser = TreeSitter::Parser.new.tap do |parser|
         parser.language = @ts_language
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,7 +5,7 @@ at_exit { GC.start }
 require 'bundler/setup'
 require 'tree_sitter'
 require 'tree_stand'
-require 'debug'
+# require 'debug'
 require 'minitest/autorun'
 require 'minitest/focus'
 require 'minitest/reporters'

--- a/test/tree_stand/parser_setup_test.rb
+++ b/test/tree_stand/parser_setup_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 class ParserSetupTest < Minitest::Test
   def test_can_parse_a_document
     parser = TreeSitter::Parser.new.tap do |p|
-      p.language = TreeSitter::Language.load('math', 'tree-sitter-parsers/math.so')
+      p.language = TreeSitter::Language.load('math', "tree-sitter-parsers/math.#{TreeSitter.ext}")
     end
 
     tree = parser.parse_string(nil, <<~MATH)


### PR DESCRIPTION
This PR contains:

1. Release of TreeSitter documentation
2. Correction of Node#pretty_print signatures (sorbet)
3. A change in the default printing device, of `TreeStand::Utils::Printer` from a `StringIO` created each time we call `pretty_print`, to something fixed in the printer class, and configurable as well, through `TreeStand.config.io`.
4. Add some sane defaults to load parsers automagically if no config is provided.



@DerekStride I did these changes while working with TreeStand, and I acknowledge the fact they could be broken into different PRs, but I just did them in a single one for convenience.

I would love to have your feedback, as I did some things on the spot and I might be missing something.