### PR TITLE
Fix Segfault bug on `child_by_field_name`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,2 @@
+---
+BasedOnStyle: LLVM

--- a/ext/tree_sitter/node.c
+++ b/ext/tree_sitter/node.c
@@ -166,14 +166,19 @@ static VALUE node_child_by_field_id(VALUE self, VALUE field_id) {
 /**
  * Get the node's child with the given field name.
  *
- * @param field_name [String]
+ * @param field_name [String, Symbol]
  *
  * @return [Node]
  */
 static VALUE node_child_by_field_name(VALUE self, VALUE field_name) {
-  const char *name = StringValuePtr(field_name);
-  uint32_t length = (uint32_t)RSTRING_LEN(field_name);
-  return new_node_by_val(ts_node_child_by_field_name(SELF, name, length));
+  if (Qtrue == rb_funcall(self, rb_intern("field?"), 1, field_name)) {
+    VALUE field_str = rb_funcall(field_name, rb_intern("to_s"), 0);
+    const char *name = StringValuePtr(field_str);
+    uint32_t length = (uint32_t)RSTRING_LEN(field_str);
+    return new_node_by_val(ts_node_child_by_field_name(SELF, name, length));
+  } else {
+    return Qnil;
+  }
 }
 
 /**

--- a/lib/tree_sitter/node.rb
+++ b/lib/tree_sitter/node.rb
@@ -16,8 +16,9 @@ module TreeSitter
       @fields
     end
 
+    # @param field [String, Symbol]
     def field?(field)
-      fields.include?(field)
+      fields.include?(field.to_sym)
     end
 
     # FIXME: These APIs (`[]` and `fetch`) need absolute fixing.

--- a/lib/tree_sitter/node.rb
+++ b/lib/tree_sitter/node.rb
@@ -13,7 +13,7 @@ module TreeSitter
         @fields << name.to_sym if name
       end
 
-      @fields
+      @fields.to_a
     end
 
     # @param field [String, Symbol]

--- a/lib/tree_sitter/node.rb
+++ b/lib/tree_sitter/node.rb
@@ -64,12 +64,12 @@ module TreeSitter
       when 0 then raise "#{self.class.name}##{__method__} requires a key."
       when 1
         case k = keys.first
-        when Numeric then named_child(k)
+        when Integer then named_child(k)
         when String, Symbol
-          raise "Cannot find field #{k}" unless fields.include?(k.to_sym)
+          raise IndexError, "Cannot find field #{k}. Available: #{fields}" unless fields.include?(k.to_sym)
 
           child_by_field_name(k.to_s)
-        else raise <<~ERR
+        else raise ArgumentError, <<~ERR
           #{self.class.name}##{__method__} accepts Integer and returns named child at given index,
               or a (String | Symbol) and returns the child by given field name.
         ERR

--- a/test/tree_sitter/node_test.rb
+++ b/test/tree_sitter/node_test.rb
@@ -243,6 +243,9 @@ describe 'field_name' do
 
   it 'must return proper field name' do
     assert_equal 'name', @child.field_name_for_child(1)
+  end
+
+  it 'must raise an exception for a wrong index' do
     assert_raises(IndexError) { @child.field_name_for_child(13) }
     assert_raises(IndexError) { @child.field_name_for_child(-13) }
   end
@@ -279,8 +282,16 @@ describe '[]' do
   it 'must return a child by field name when index is a (String | Symbol)' do
     assert_equal @child.named_child(0), @child[:name]
     assert_equal @child.named_child(0), @child['name']
-    assert_raises(RuntimeError) { @child['something'] }
-    assert_raises(RuntimeError) { @child[:something] }
+  end
+
+  it 'must raise an exception when index is does not exist' do
+    assert_raises(IndexError) { @child[13] }
+    assert_raises(IndexError) { @child['something'] }
+    assert_raises(IndexError) { @child[:something] }
+    assert_raises(ArgumentError) { @child[1.0] }
+    assert_raises(ArgumentError) { @child[[:name]] }
+    assert_raises(ArgumentError) { @child[[:something]] }
+    assert_raises(ArgumentError) { @child[{ name: :something }] }
   end
 
   it 'must return an array of nodes when index is an Array' do

--- a/test/tree_sitter/node_test.rb
+++ b/test/tree_sitter/node_test.rb
@@ -137,6 +137,13 @@ describe 'child' do
     @child = root.child(0)
   end
 
+  it 'must know whether a field exists' do
+    assert_equal true, @child.field?('name')
+    assert_equal true, @child.field?(:name)
+    assert_equal false, @child.field?('something')
+    assert_equal false, @child.field?(:something)
+  end
+
   it 'must return proper children count' do
     assert_equal 1, root.child_count
   end
@@ -151,6 +158,9 @@ describe 'child' do
 
   it 'must return proper child by field name' do
     assert_equal @child.child(1), @child.child_by_field_name('name')
+    assert_equal @child.child(1), @child.child_by_field_name(:name)
+    assert_nil @child.child_by_field_name('something')
+    assert_nil @child.child_by_field_name(:something)
   end
 
   it 'must return proper child by field id' do

--- a/test/tree_sitter/node_test.rb
+++ b/test/tree_sitter/node_test.rb
@@ -132,6 +132,24 @@ describe 'parent' do
   end
 end
 
+describe 'named_child' do
+  before do
+    @child = root.child(0)
+  end
+
+  it 'must return proper node' do
+    assert_equal @child.named_child(0), @child.child_by_field_name('name')
+    assert_equal @child.named_child(0), @child.child_by_field_name(:name)
+    assert_equal @child.named_child(1), @child.child_by_field_name('parameters')
+    assert_equal @child.named_child(1), @child.child_by_field_name(:parameters)
+  end
+
+  it 'must raise IndexError when out of range' do
+    assert_raises(IndexError) { @child.named_child(13) }
+    assert_raises(IndexError) { @child.named_child(-13) }
+  end
+end
+
 describe 'child' do
   before do
     @child = root.child(0)
@@ -199,12 +217,10 @@ describe 'child' do
 
   it 'must raise an exception for wrong ranges' do
     child = @child.child(0)
-    assert_raises IndexError do
-      @child.descendant_for_byte_range(child.end_byte, child.start_byte)
-    end
-    assert_raises IndexError do
-      @child.named_descendant_for_byte_range(child.end_byte, child.start_byte)
-    end
+    assert_raises(IndexError) { root.child(13).parent }
+    assert_raises(IndexError) { root.child(-13).parent }
+    assert_raises(IndexError) { @child.descendant_for_byte_range(child.end_byte, child.start_byte) }
+    assert_raises(IndexError) { @child.named_descendant_for_byte_range(child.end_byte, child.start_byte) }
     assert_raises IndexError do
       p1 = TreeSitter::Point.new
       p1.row = @child.end_point.row
@@ -227,6 +243,8 @@ describe 'field_name' do
 
   it 'must return proper field name' do
     assert_equal 'name', @child.field_name_for_child(1)
+    assert_raises(IndexError) { @child.field_name_for_child(13) }
+    assert_raises(IndexError) { @child.field_name_for_child(-13) }
   end
 end
 
@@ -261,6 +279,8 @@ describe '[]' do
   it 'must return a child by field name when index is a (String | Symbol)' do
     assert_equal @child.named_child(0), @child[:name]
     assert_equal @child.named_child(0), @child['name']
+    assert_raises(RuntimeError) { @child['something'] }
+    assert_raises(RuntimeError) { @child[:something] }
   end
 
   it 'must return an array of nodes when index is an Array' do


### PR DESCRIPTION
This PR contains:

1. An improvement on `Node#field?`, accepting strings and symbols.
2. Fixing segfaults on calls to `Node#child_by_filed_name`, returning `nil` when the field name does not exist, also accepting strings and symbols.
3. Improvements on tests.