### PR TITLE
Make `TreeSitter::{QueryMatches, QueryCaptures}` enumerable and support predicates in `TreeStand`

### DIFF
--- a/News.md
+++ b/News.md
@@ -3,6 +3,8 @@
 - `TreeSitter::Node` is enumerable.
 - `TreeSitter::{QueryCaptures, QueryMatches}` are enumerable.
 - `TreeStand::Node` now supports query predicates from `TreeSitter`.
+- `TreeSitter::QueryMatches` now has a `each_capture_hash` method returning an `Enumerator<Hash<String, Node>>`,
+  the rough equivalent of what `TreeStand::Node#query` returns.
 
 # v1.3.0
 

--- a/News.md
+++ b/News.md
@@ -1,5 +1,7 @@
 # News
 
+- `TreeSitter::Node` is enumerable.
+
 # v1.3.0
 
 - Query Predicates landed. See https://tree-sitter.github.io/tree-sitter/using-parsers#predicates.

--- a/News.md
+++ b/News.md
@@ -1,6 +1,7 @@
 # News
 
 - `TreeSitter::Node` is enumerable.
+- `TreeSitter::{QueryCaptures, QueryMatches}` are enumerable.
 
 # v1.3.0
 

--- a/News.md
+++ b/News.md
@@ -2,6 +2,7 @@
 
 - `TreeSitter::Node` is enumerable.
 - `TreeSitter::{QueryCaptures, QueryMatches}` are enumerable.
+- `TreeStand::Node` now supports query predicates from `TreeSitter`.
 
 # v1.3.0
 

--- a/bin/check
+++ b/bin/check
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+bundle exec rake clean compile
 bundle exec rake test
 bundle exec rubocop --config .rubocop.yml
+bundle exec srb tc
 bundle exec yard

--- a/lib/tree_sitter/node.rb
+++ b/lib/tree_sitter/node.rb
@@ -3,6 +3,8 @@
 module TreeSitter
   # Node is a wrapper around a tree-sitter node.
   class Node
+    include Enumerable
+
     # @return [Array<Symbol>] the node's named fields
     def fields
       return @fields if @fields
@@ -87,10 +89,10 @@ module TreeSitter
     # Iterate over a node's children.
     #
     # @yieldparam child [Node] the child
-    def each
+    def each(&_block)
       return enum_for __method__ if !block_given?
 
-      (0...(child_count)).each do |i|
+      (0...child_count).each do |i|
         yield child(i)
       end
     end

--- a/lib/tree_sitter/query_captures.rb
+++ b/lib/tree_sitter/query_captures.rb
@@ -3,6 +3,8 @@
 module TreeSitter
   # A sequence of {TreeSitter::QueryCapture} associated with a given {TreeSitter::QueryCursor}.
   class QueryCaptures
+    include Enumerable
+
     def initialize(cursor, query, src)
       @cursor = cursor
       @query = query
@@ -13,7 +15,7 @@ module TreeSitter
     #
     # @yieldparam match [TreeSitter::QueryMatch]
     # @yieldparam capture_index [Integer]
-    def each
+    def each(&_block)
       return enum_for __method__ if !block_given?
 
       while (capture_index, match = @cursor.next_capture)

--- a/lib/tree_sitter/query_matches.rb
+++ b/lib/tree_sitter/query_matches.rb
@@ -3,6 +3,8 @@
 module TreeSitter
   # A sequence of {QueryMatch} associated with a given {QueryCursor}.
   class QueryMatches
+    include Enumerable
+
     def initialize(cursor, query, src)
       @cursor = cursor
       @query = query
@@ -12,7 +14,7 @@ module TreeSitter
     # Iterator over matches.
     #
     # @yieldparam match [TreeSitter::QueryMatch]
-    def each
+    def each(&_block)
       return enum_for __method__ if !block_given?
 
       while match = @cursor.next_match

--- a/lib/tree_sitter/query_matches.rb
+++ b/lib/tree_sitter/query_matches.rb
@@ -23,5 +23,17 @@ module TreeSitter
         end
       end
     end
+
+    # Iterate over all the results presented as hashes of `capture name => node`.
+    #
+    # @yieldparam match [Hash<String, TreeSitter::Node>]
+    def each_capture_hash(&_block)
+      # TODO: should we return [Array<Hash<Symbol, TreeSitter::Node]>>] instead?
+      return enum_for __method__ if !block_given?
+
+      each do |match|
+        yield match.captures.to_h { |cap| [@query.capture_name_for_id(cap.index), cap.node] }
+      end
+    end
   end
 end

--- a/lib/tree_stand/node.rb
+++ b/lib/tree_stand/node.rb
@@ -100,16 +100,8 @@ module TreeStand
       TreeSitter::QueryCursor
         .new
         .matches(ts_query, @tree.ts_tree.root_node, @tree.document)
-        .map do |match|
-          match
-            .captures
-            .to_h do |cap|
-              [
-                ts_query.capture_name_for_id(cap.index),
-                TreeStand::Node.new(@tree, cap.node),
-              ]
-            end
-        end
+        .each_capture_hash
+        .map { |h| h.transform_values! { |n| TreeStand::Node.new(@tree, n) } }
     end
 
     # Returns the first captured node that matches the query string or nil if

--- a/lib/tree_stand/node.rb
+++ b/lib/tree_stand/node.rb
@@ -97,19 +97,19 @@ module TreeStand
     sig { params(query_string: String).returns(T::Array[T::Hash[String, TreeStand::Node]]) }
     def query(query_string)
       ts_query = TreeSitter::Query.new(@tree.parser.ts_language, query_string)
-      ts_cursor = TreeSitter::QueryCursor.exec(ts_query, ts_node)
-      matches = []
-      while ts_match = ts_cursor.next_match
-        captures = {}
-
-        ts_match.captures.each do |ts_capture|
-          capture_name = ts_query.capture_name_for_id(ts_capture.index)
-          captures[capture_name] = TreeStand::Node.new(@tree, ts_capture.node)
+      TreeSitter::QueryCursor
+        .new
+        .matches(ts_query, @tree.ts_tree.root_node, @tree.document)
+        .map do |match|
+          match
+            .captures
+            .to_h do |cap|
+              [
+                ts_query.capture_name_for_id(cap.index),
+                TreeStand::Node.new(@tree, cap.node),
+              ]
+            end
         end
-
-        matches << captures
-      end
-      matches
     end
 
     # Returns the first captured node that matches the query string or nil if

--- a/test/tree_sitter/node_test.rb
+++ b/test/tree_sitter/node_test.rb
@@ -339,6 +339,12 @@ describe 'each' do
   end
 end
 
+describe 'Enumerable' do
+  it 'should be' do
+    _(root.class.ancestors).must_be :include?, Enumerable
+  end
+end
+
 describe 'method_missing' do
   before do
     @child = root.child(0)

--- a/test/tree_sitter/query_test.rb
+++ b/test/tree_sitter/query_test.rb
@@ -152,6 +152,40 @@ describe 'querying anonymous nodes' do
   end
 end
 
+describe 'captures and matches' do
+  it 'should be enumerable' do
+    src = <<~MATH
+      1 + x * 3
+    MATH
+    math = TreeSitter.lang('math')
+    parser = TreeSitter::Parser.new
+    parser.language = math
+    tree = parser.parse_string(nil, src)
+    query_string = '(sum) @sum'
+
+    query = TreeSitter::Query.new(math, query_string)
+    matches = -> { TreeSitter::QueryCursor.new.matches(query, tree.root_node, src) }
+    captures = -> { TreeSitter::QueryCursor.new.captures(query, tree.root_node, src) }
+
+    _(matches.call.class.ancestors).must_be :include?, Enumerable
+    _(captures.call.class.ancestors).must_be :include?, Enumerable
+
+    _(matches.call.all? { |e| !e.nil? }).must_equal true
+    _(matches.call.any? { |e| !e.nil? }).must_equal true
+    _(matches.call.map { |e| e }.count).must_equal matches.call.count
+
+    _(captures.call.all? { |e| !e.nil? }).must_equal true
+    _(captures.call.any? { |e| !e.nil? }).must_equal true
+    _(captures.call.map { |e| e }.count).must_equal captures.call.count
+    # TODO: review TreeSitter::Node equality functions.
+    # The following assertions will fail now because of how [`ts_node_eq`](https://github.com/tree-sitter/tree-sitter/blob/9d1ac2139221b2e19389ca620767c537607a2f63/lib/src/node.c#L453)
+    # is implemented
+    #
+    # _(matches.().to_a.first).must_equal matches.().first
+    # _(captures.().to_a.first).must_equal captures.().first
+  end
+end
+
 describe 'query predicates' do
   it 'should handle string equality and regex matching' do
     src = <<~MATH
@@ -191,12 +225,12 @@ describe 'query predicates' do
       c = TreeSitter::QueryCursor.new
       assert_equal(
         t[:matches],
-        c.matches(q, tree.root_node, src).each.to_a.length,
+        c.matches(q, tree.root_node, src).count,
         "bad  matches for query #{t[:query]}",
       )
       assert_equal(
         t[:captures],
-        c.captures(q, tree.root_node, src).each.to_a.length,
+        c.captures(q, tree.root_node, src).count,
         "bad  captures for query #{t[:query]}",
       )
     end
@@ -225,12 +259,12 @@ describe 'query predicates' do
       c = TreeSitter::QueryCursor.new
       assert_equal(
         t[:matches],
-        c.matches(q, tree.root_node, src).each.to_a.length,
+        c.matches(q, tree.root_node, src).count,
         "bad matches for query #{t[:query]}",
       )
       assert_equal(
         t[:captures],
-        c.captures(q, tree.root_node, src).each.to_a.length,
+        c.captures(q, tree.root_node, src).count,
         "bad captures for query #{t[:query]}",
       )
     end
@@ -279,12 +313,12 @@ describe 'query predicates' do
       c = TreeSitter::QueryCursor.new
       assert_equal(
         t[:matches],
-        c.matches(q, tree.root_node, src).each.to_a.length,
+        c.matches(q, tree.root_node, src).count,
         "bad matches for query #{t[:query]}",
       )
       assert_equal(
         t[:captures],
-        c.captures(q, tree.root_node, src).each.to_a.length,
+        c.captures(q, tree.root_node, src).count,
         "bad captures for query #{t[:query]}",
       )
     end
@@ -319,12 +353,12 @@ describe 'query predicates' do
       c = TreeSitter::QueryCursor.new
       assert_equal(
         t[:matches],
-        c.matches(q, tree.root_node, src).each.to_a.length,
+        c.matches(q, tree.root_node, src).count,
         "bad matches for query #{t[:query]}",
       )
       assert_equal(
         t[:captures],
-        c.captures(q, tree.root_node, src).each.to_a.length,
+        c.captures(q, tree.root_node, src).count,
         "bad captures for query #{t[:query]}",
       )
     end

--- a/test/tree_stand/node_test.rb
+++ b/test/tree_stand/node_test.rb
@@ -199,8 +199,9 @@ class NodeTest < Minitest::Test
       (sum) @sum
     QUERY
 
-    assert_equal(1, matches.size)
-    assert_equal('1 + x * 3', matches.dig(0, 'sum').text)
+    assert_equal(2, matches.size)
+    assert_equal('1 + x * 3 + 2', matches.dig(0, 'sum').text)
+    assert_equal('1 + x * 3', matches.dig(1, 'sum').text)
   end
 
   def test_error_nodes


### PR DESCRIPTION
- `TreeSitter::Node` is enumerable.
- `TreeSitter::{QueryCaptures, QueryMatches}` are enumerable.
- `TreeStand::Node` now supports query predicates from `TreeSitter`.
- `TreeSitter::QueryMatches` now has a `collect` method returning an `Array<Hash<String, Node>>`,
  the equivalent of what `TreeStand::Node#query` returns.
