### PR TITLE
Disable native gem / cross-compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,49 +9,52 @@ on:
     - master
 
 jobs:
-  native-gems:
-    strategy:
-      fail-fast: false
-      matrix:
-        ruby: [3.0, 3.1, 3.2, 3.3]
-        platform:
-          - { os: ubuntu, target: linux-x64 }
-          - { os: macos,  target: macos-arm64 }
-    runs-on: ${{ matrix.platform.os }}-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: extractions/setup-just@v1
-      - name: setup ruby ${{ matrix.ruby }}
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby }}
-      - name: build and install tree-sitter
-        run: just setup-ts
-      - name: ldconfig
-        if: ${{ matrix.platform.os == 'ubuntu' }}
-        run: sudo ldconfig -v
-      - name: setup
-        env:
-          PLATFORM: ${{ matrix.platform.target }}
-        run: just setup
-      - name: compile
-        run: just compile
-      - name: test
-        run: just test
-      - name: package native gem
-        run: |
-          just gem-native
-          for file in pkg/*.gem; do mv $file ${file%.*}-mri-${{ matrix.ruby }}.gem; done;
-      - name: release
-        if: github.event_name != 'pull_request'
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: ${{ github.ref }}-${{ steps.vars.outputs.sha_short }}
-          draft: true
-          files: |
-            ./pkg/*
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  # FIXME: Native gem production and --disable-sys-libs are not working together
+  # correctly, that's why they're disabled for now.
+  #
+  # native-gems:
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       ruby: [3.0, 3.1, 3.2, 3.3]
+  #       platform:
+  #         - { os: ubuntu, target: linux-x64 }
+  #         - { os: macos,  target: macos-arm64 }
+  #   runs-on: ${{ matrix.platform.os }}-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: extractions/setup-just@v1
+  #     - name: setup ruby ${{ matrix.ruby }}
+  #       uses: ruby/setup-ruby@v1
+  #       with:
+  #         ruby-version: ${{ matrix.ruby }}
+  #     - name: build and install tree-sitter
+  #       run: just setup-ts
+  #     - name: ldconfig
+  #       if: ${{ matrix.platform.os == 'ubuntu' }}
+  #       run: sudo ldconfig -v
+  #     - name: setup
+  #       env:
+  #         PLATFORM: ${{ matrix.platform.target }}
+  #       run: just setup
+  #     - name: compile
+  #       run: just compile
+  #     - name: test
+  #       run: just test
+  #     - name: package native gem
+  #       run: |
+  #         just gem-native
+  #         for file in pkg/*.gem; do mv $file ${file%.*}-mri-${{ matrix.ruby }}.gem; done;
+  #     - name: release
+  #       if: github.event_name != 'pull_request'
+  #       uses: softprops/action-gh-release@v1
+  #       with:
+  #         tag_name: ${{ github.ref }}-${{ steps.vars.outputs.sha_short }}
+  #         draft: true
+  #         files: |
+  #           ./pkg/*
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # - We need this seperate step for now to avoid duplicate uploads on release
   # - We're not testing here also because it's been taken care of in the previous

--- a/Gemfile
+++ b/Gemfile
@@ -6,20 +6,20 @@ gemspec
 
 group :development, :test do
   gem 'bundler', '~> 2.3'
-  gem 'debug', '~> 1.7', require: false
-  gem 'rake', '~> 13.0'
+  gem 'debug', '~> 1.9', require: false
+  gem 'rake', '~> 13.2'
   gem 'rake-compiler', '~> 1.2'
-  gem 'rake-compiler-dock', '~> 1.2'
+  gem 'rake-compiler-dock', '~> 1.5'
   gem 'rubocop', '~> 1.39.0', require: false
-  gem 'ruby-lsp', require: false
-  gem 'ruby_memcheck', '~> 1.0'
-  gem 'tapioca', '~> 0.11.1', require: false
-  gem 'webrick'
-  gem 'yard', '~> 0.9.36'
+  gem 'ruby-lsp', '~> 0.17', require: false
+  gem 'ruby_memcheck', '~> 1.3'
+  gem 'tapioca', '~> 0.11', require: false
+  gem 'webrick', '~> 1.8'
+  gem 'yard', '~> 0.9'
 end
 
 group :test do
-  gem 'minitest', '~> 5.17'
-  gem 'minitest-focus', '~> 1.3'
-  gem 'minitest-reporters', '~> 1.5'
+  gem 'minitest', '~> 5.23'
+  gem 'minitest-focus', '~> 1.4'
+  gem 'minitest-reporters', '~> 1.6'
 end

--- a/News.md
+++ b/News.md
@@ -1,5 +1,7 @@
 # News
 
+# v1.5.0
+
 - Cross-compilation support is dropped because it doesn't work with `--disable-sys-lib`.
   We need a better understanding of rake-compiler-dock and rake-compiler.
   _v1.4.2 is especially broken_.

--- a/News.md
+++ b/News.md
@@ -1,5 +1,10 @@
 # News
 
+- Cross-compilation support is dropped because it doesn't work with `--disable-sys-lib`.
+  We need a better understanding of rake-compiler-dock and rake-compiler.
+  _v1.4.2 is especially broken_.
+  **Skip all v1.4**.
+
 # v1.4.2
 
 - Remove sorbet's `T.unsafe`. This prevented `TreeSitter.language` to function outside of `TreeStand`.

--- a/Rakefile
+++ b/Rakefile
@@ -15,60 +15,67 @@ require 'ruby_memcheck'
 
 gemspec = Gem::Specification.load('tree_sitter.gemspec')
 
-cross_rubies = [
-  '3.2.0',
-  '3.1.0',
-  '3.0.0',
-  '2.7.0',
-].freeze
-
-cross_platforms = [
-  'x64-mingw32',
-  'x64-mingw-ucrt',
-  'x86-linux',
-  'x86_64-linux',
-  'aarch64-linux',
-  #
-  # FIXME: ld: unknown -soname
-  # that's a bug in tree-sitter's makefile: it only checks for OS type and
-  # not compiler type, so when we're cross-building it blows in our face
-  #
-  'x86_64-darwin',
-  'arm64-darwin',
-].freeze
-
-ENV['RUBY_CC_VERSION'] = cross_rubies.join(':') if !ENV['RUBY_CC_VERSION']
-Rake::ExtensionTask.new('tree_sitter', gemspec) do |r|
-  r.lib_dir = 'lib/tree_sitter'
-  require 'rake_compiler_dock'
-  r.cross_compile = true
-  r.cross_platform = cross_platforms
-  r.cross_compiling do |spec|
-    spec.files.reject! { |file| /(\.gz)$|(\.zip)$|(\.tar)$/ =~ File.basename(file) }
-  end
+Gem::PackageTask.new(gemspec) do |task|
 end
 
-Gem::PackageTask.new(gemspec) do |pkg|
+Rake::ExtensionTask.new('tree_sitter', gemspec) do |task|
+  task.lib_dir = 'lib/tree_sitter'
 end
 
-desc 'Build native gems'
-task 'gem:native' do
-  cross_platforms.each do |plat|
-    RakeCompilerDock.sh(
-      "gem update --system --no-document && bundle && bundle exec rake clean && bundle exec rake native:#{plat} gem",
-      platform: plat,
-    )
-  end
-end
-
-cross_platforms.each do |plat|
-  task "gem:#{plat}" do
-    RakeCompilerDock.sh(
-      "gem update --system --no-document && bundle && bundle exec rake clean && bundle exec rake native:#{plat} gem",
-      platform: plat,
-    )
-  end
-end
+# FIXME: Native gem production and --disable-sys-libs are not working together
+# correctly, that's why they're disabled for now.
+#
+# cross_rubies = [
+#   '3.2.0',
+#   '3.1.0',
+#   '3.0.0',
+#   '2.7.0',
+# ].freeze
+#
+# cross_platforms = [
+#   'x64-mingw32',
+#   'x64-mingw-ucrt',
+#   'x86-linux',
+#   'x86_64-linux',
+#   'aarch64-linux',
+#   #
+#   # FIXME: ld: unknown -soname
+#   # that's a bug in tree-sitter's makefile: it only checks for OS type and
+#   # not compiler type, so when we're cross-building it blows in our face
+#   #
+#   'x86_64-darwin',
+#   'arm64-darwin',
+# ].freeze
+#
+# ENV['RUBY_CC_VERSION'] = cross_rubies.join(':') if !ENV['RUBY_CC_VERSION']
+# Rake::ExtensionTask.new('tree_sitter', gemspec) do |r|
+#   r.lib_dir = 'lib/tree_sitter'
+#   require 'rake_compiler_dock'
+#   r.cross_compile = true
+#   r.cross_platform = cross_platforms
+#   r.cross_compiling do |spec|
+#     spec.files.reject! { |file| /(\.gz)$|(\.zip)$|(\.tar)$/ =~ File.basename(file) }
+#   end
+# end
+#
+# desc 'Build native gems'
+# task 'gem:native' do
+#   cross_platforms.each do |plat|
+#     RakeCompilerDock.sh(
+#       "gem update --system --no-document && bundle && bundle exec rake clean && bundle exec rake native:#{plat} gem",
+#       platform: plat,
+#     )
+#   end
+# end
+#
+# cross_platforms.each do |plat|
+#   task "gem:#{plat}" do
+#     RakeCompilerDock.sh(
+#       "gem update --system --no-document && bundle && bundle exec rake clean && bundle exec rake native:#{plat} gem",
+#       platform: plat,
+#     )
+#   end
+# end
 
 task :clean do
   require 'fileutils'

--- a/bin/publish
+++ b/bin/publish
@@ -1,9 +1,12 @@
 #! /usr/bin/env sh
 set -e
 
+# FIXME: Whenever cross-compilarion is active again, we need to restore the proper
+# gem publishing filters, notably: grep "ruby_tree_sitter.*mri-3.3"
+#
 # We need to filter 1 type of ruby versions because rubygems.org doesn't allow
 # multiple push of the same version.
-find pkg -name "*.gem" | grep "ruby_tree_sitter.*mri-3.3" | while read packaged_gem; do
+find pkg -name "*.gem" | while read packaged_gem; do
   echo "Publishing $packaged_gem"
   gem push "$packaged_gem"
 done

--- a/lib/tree_sitter/version.rb
+++ b/lib/tree_sitter/version.rb
@@ -4,5 +4,5 @@ module TreeSitter
   # The version of the tree-sitter library.
   TREESITTER_VERSION = '0.22.6'
   # The current version of the gem.
-  VERSION = '1.4.2'
+  VERSION = '1.5.0'
 end


### PR DESCRIPTION
I'm either missing on something in the docs of rake-compiler and
rake-compiler-dock, or the doc is missing some crucial information.

Trying to read the existing repos is not helping that much neither
(especially Nokogiri).

If I find the opportunity to spend all the time necessary to fix this, I
would gladly spend it. If someone else would like to contribute, it will
be even better, because I don't think it's possible in the near future.