### PR TITLE
mixin: language: do not duplicate names

### DIFF
--- a/lib/tree_sitter/mixins/language.rb
+++ b/lib/tree_sitter/mixins/language.rb
@@ -126,6 +126,7 @@ module TreeSitter
       def search_for_lib(name)
         files =
           [name, name.upcase, name.downcase]
+            .uniq
             .flat_map do |n|
               base = "#{n}.#{ext}"
               [base, "tree-sitter-#{base}", "libtree-sitter-#{base}"]


### PR DESCRIPTION
Well this missed the 1.5.1 train, but it's not really a big deal.