### PR TITLE
Cross compile: patch macos target

### DIFF
--- a/News.md
+++ b/News.md
@@ -1,5 +1,17 @@
 # News
 
+- Cross-compilation is now working for most targets:
+  + `aarch64-linux-gnu`
+  + `aarch64-linux-musl`
+  + `arm-linux-gnu`
+  + `arm-linux-musl`
+  + `x86_64-linux-gnu`
+  + `x86_64-linux-musl`
+  + `x86-linux-musl`
+  + `arm64-darwin`
+  + `x86_64-darwin`
+  We now produce fat native gems so you don't have to install tree-sitter on your machine,
+  and not even compile it if you don't need to.
 # v1.5.1
 
 - Language loading, e.g. `TreeSitter.lang`, is now case insensitive for path lookup only:

--- a/Rakefile
+++ b/Rakefile
@@ -4,19 +4,13 @@ require 'rake/extensiontask'
 require 'rake/testtask'
 require 'ruby_memcheck'
 
-# FIXME: ld: unknown -soname
-# that's a bug in tree-sitter's makefile: it only checks for OS type and
-# not compiler type, so when we're cross-building it blows in our face
-#     x86_64-darwin
-#     arm64-darwin
-# However, these don't work at all with tree-sitter:
+# NOTE: tree-sitter does not support:
 #     x64-mingw-ucrt
 #     x64-mingw32
 #     x86-mingw32
-# And here, bundler is segfaulting
-#     x86-linux-gnu
-#     x86-linux-musl
 #
+# NOTE: bundler is segfaulting on:
+#     x86-linux-gnu
 PLATFORMS = %w[
   aarch64-linux-gnu
   aarch64-linux-musl
@@ -24,6 +18,9 @@ PLATFORMS = %w[
   arm-linux-musl
   x86_64-linux-gnu
   x86_64-linux-musl
+  x86-linux-musl
+  arm64-darwin
+  x86_64-darwin
 ].freeze
 
 CROSS_RUBIES = %w[3.3.0 3.2.0 3.1.0 3.0.0].freeze

--- a/Rakefile
+++ b/Rakefile
@@ -39,6 +39,7 @@ Rake::ExtensionTask.new('tree_sitter', gemspec) do |task|
   task.lib_dir = 'lib/tree_sitter'
   task.cross_compile = true
   task.cross_platform = PLATFORMS
+  task.cross_config_options << '--enable-cross-build'
 end
 
 task 'gem:native' do

--- a/ext/tree_sitter/extconf.rb
+++ b/ext/tree_sitter/extconf.rb
@@ -26,6 +26,8 @@ end
 #    System lib vs Downloaded lib    #
 # ################################## #
 
+repo = TreeSitter::Repo.new
+
 dir_include, dir_lib =
   if system_tree_sitter?
     [
@@ -33,7 +35,6 @@ dir_include, dir_lib =
       %w[/opt/lib /opt/local/lib /usr/lib /usr/local/lib],
     ]
   else
-    repo = TreeSitter::Repo.new
     if !repo.download
       msg = <<~MSG
 
@@ -53,14 +54,14 @@ dir_include, dir_lib =
     repo.include_and_lib_dirs
   end
 
+dir_config('tree-sitter', dir_include&.first, dir_lib&.first)
+
 # ################################## #
 #          Generate Makefile         #
 # ################################## #
 
-header = find_header('tree_sitter/api.h', *dir_include)
-library = find_library('tree-sitter',   # libtree-sitter
-                       'ts_parser_new', # a symbol
-                       *dir_lib)
+header = find_header('tree_sitter/api.h')
+library = find_library('tree-sitter', 'ts_parser_new')
 
 if !header || !library
   abort <<~MSG
@@ -144,6 +145,5 @@ cflags.concat %w[-std=c99 -fPIC -Wall]
 append_cflags(cflags)
 append_ldflags(ldflags)
 
-dir_config('tree-sitter')
 create_header
 create_makefile('tree_sitter/tree_sitter')

--- a/ext/tree_sitter/extconf.rb
+++ b/ext/tree_sitter/extconf.rb
@@ -49,6 +49,7 @@ dir_include, dir_lib =
     # We need to make sure we're selecting the proper toolchain.
     # Especially needed for corss-compilation.
     ENV.store('CC', RbConfig::CONFIG['CC'])
+    repo.patch
     repo.compile
     repo.keep_static_lib
     repo.include_and_lib_dirs

--- a/ext/tree_sitter/repo.rb
+++ b/ext/tree_sitter/repo.rb
@@ -59,7 +59,7 @@ module TreeSitter
     end
 
     def include_and_lib_dirs
-      [[src / 'lib' / 'include'], [src.to_s]]
+      [[(src / 'lib' / 'include').to_s], [src.to_s]]
     end
 
     def keep_static_lib

--- a/ext/tree_sitter/repo.rb
+++ b/ext/tree_sitter/repo.rb
@@ -29,7 +29,9 @@ module TreeSitter
     def compile
       # We need to clean because the same folder is used over and over
       # by rake-compiler-dock
-      sh "cd #{src} && make clean && make"
+      ar = RbConfig::MAKEFILE_CONFIG['AR']
+      ar = " AR=#{ar}" if ar
+      sh "cd #{src} && make clean &&#{ar} make"
     end
 
     def exe?(name)
@@ -67,6 +69,13 @@ module TreeSitter
         .children
         .filter { |f| /\.(dylib|so)/ =~ f.basename.to_s }
         .each(&:unlink)
+    end
+
+    def patch
+      root = Pathname.new(File.expand_path(__dir__)).realpath.parent.parent
+      patch = root / 'patches' / 'cross-compile.patch'
+
+      sh "patch --forward #{src / 'Makefile'} #{patch}"
     end
 
     def sh(cmd)

--- a/patches/cross-compile.patch
+++ b/patches/cross-compile.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+index e021e87..fb9d2ef 100644
+--- a/Makefile
++++ b/Makefile
+@@ -30,7 +30,7 @@ SONAME_MINOR := $(word 2,$(subst ., ,$(VERSION)))
+ # OS-specific bits
+ ifeq ($(OS),Windows_NT)
+ 	$(error "Windows is not supported")
+-else ifeq ($(shell uname),Darwin)
++else ifeq ($(findstring darwin, $(shell $(CC) -dumpmachine)), darwin)
+ 	SOEXT = dylib
+ 	SOEXTVER_MAJOR = $(SONAME_MAJOR).dylib
+ 	SOEXTVER = $(SONAME_MAJOR).$(SONAME_MINOR).dylib


### PR DESCRIPTION
# MacOS target

Macos targets didn't compile because the makefile of tree-sitter didn't work in cross-compilation environments.

My last patch was obviously wrong: https://github.com/tree-sitter/tree-sitter/pull/1824

I checked the new way with this test-suite and it's good.