### PR TITLE
Bump to v1.6.0

### DIFF
--- a/bin/publish
+++ b/bin/publish
@@ -9,7 +9,7 @@ set -ex
 
 version=$(ruby -r ./lib/tree_sitter/version.rb -e 'puts TreeSitter::VERSION')
 
-find pkg -name "ruby_tree_sitter-$version.gem" | while read packaged_gem; do
+find pkg -name "ruby_tree_sitter-$version*.gem" | while read packaged_gem; do
   echo "Publishing $packaged_gem"
   gem push "$packaged_gem"
 done

--- a/lib/tree_sitter/version.rb
+++ b/lib/tree_sitter/version.rb
@@ -4,5 +4,5 @@ module TreeSitter
   # The version of the tree-sitter library.
   TREESITTER_VERSION = '0.22.6'
   # The current version of the gem.
-  VERSION = '1.5.1'
+  VERSION = '1.6.0'
 end


### PR DESCRIPTION
And publish all cross-compiled gems. See https://github.com/Faveod/ruby-tree-sitter/pull/70.