### PR TITLE
ci: automatically bump tree-sitter on new releases

### DIFF
--- a/.github/workflows/bump-tree-sitter.yml
+++ b/.github/workflows/bump-tree-sitter.yml
@@ -1,0 +1,68 @@
+name: Automatic tree-sitter version bump
+
+on:
+  schedule:
+    - cron: "23 1 * * *"
+
+jobs:
+  check_release:
+    name: Check latest release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Get the previous release tag from local project
+        id: previous_release
+        run: |
+          PREVIOUS_RELEASE=$(ruby -r ./lib/tree_sitter/version.rb -e 'puts TreeSitter::TREESITTER_VERSION')
+          echo "version=$PREVIOUS_RELEASE" >> "$GITHUB_OUTPUT"
+
+      - name: Get the latest release tag from the external repo
+        id: latest_release
+        run: |
+          LATEST_RELEASE=$(curl -s https://api.github.com/repos/tree-sitter/tree-sitter/releases/latest | jq -r .tag_name | sed 's/^v//')
+          echo "version=$LATEST_RELEASE" >> "$GITHUB_OUTPUT"
+          echo "branch=tree-sitter-bump-to-$LATEST_RELEASE" >> "$GITHUB_OUTPUT"
+
+      - name: Check if branch exists
+        id: latest_release_branch
+        run: |
+          git pull
+          if git show-ref --verify --quiet refs/heads/${{ steps.latest_release.outputs.branch }}; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Compare release versions
+        id: check_versions
+        run: |
+          if [ "${{ steps.previous_release.outputs.version }}" != "${{ steps.latest_release.outputs.version }}" ]; then
+            echo "New release found"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No new release"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Update version if changed
+        if: steps.check_versions.outputs.changed == 'true'
+        run: |
+          sed -i "s/^\([[:space:]]*\)TREESITTER_VERSION = '.*'/\1TREESITTER_VERSION = '${{ steps.latest_release.outputs.version }}'/"  lib/tree_sitter/version.rb
+
+      - name: Create pull request
+        if: steps.check_versions.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
+          base: ${{ github.event.repository.default_branch }}
+          branch: ${{ steps.latest_release.outputs.branch }}
+          commit-message: "tree-sitter: bump to ${{ steps.latest_release.outputs.version }}"
+          committer: github-actions[bot] <github-actions[bot]@github.com>
+          delete-branch: true
+          draft: always-true
+          signoff: false
+          title: "Bump tree-sitter to ${{ steps.latest_release.outputs.version }}"
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ logs
 
 /.yardoc
 /doc
-/docs
 /log
 /pkg
 /tmp

--- a/bin/ci-push-gems
+++ b/bin/ci-push-gems
@@ -2,6 +2,9 @@
 set -exuo pipefail
 IFS=$'\n\t'
 
+bundle config set --local path vendor
+bundle install
+
 if bundle exec gemstash status; then
     echo "Gemstash is already up."
 else

--- a/bin/ci-test-project
+++ b/bin/ci-test-project
@@ -12,6 +12,6 @@ version=$(ruby -r ./lib/tree_sitter/version.rb -e 'puts TreeSitter::VERSION')
 cp -R examples/test-project /tmp
 cd /tmp/test-project
 sed -i.bak "s/\$version/$version/" Gemfile
-bundle config set --local path vendor/bundle
+bundle config set --local path vendor
 bundle install
 bundle exec ruby main.rb || echo "You may need to set envvar TREE_SITTER_PARSERS."

--- a/docker/base.dockerfile
+++ b/docker/base.dockerfile
@@ -1,0 +1,47 @@
+FROM ruby:latest
+
+ENV HOME="/root"
+WORKDIR ${HOME}
+
+# Set up external packages
+RUN apt update
+RUN apt install -y lsb-release apt-transport-https ca-certificates
+RUN wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
+RUN echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/php.list
+RUN apt update
+RUN apt upgrade -y
+# Every command is on a single line because it makes testing easier
+# Build dependencies
+RUN apt install -y build-essential
+RUN apt install -y curl
+RUN apt install -y git
+# Language tools
+RUN apt install -y nodejs
+RUN apt install -y npm
+RUN apt install -y openjdk-17-jdk
+RUN apt install -y php8.2
+RUN apt install -y php8.2-mbstring
+RUN apt install -y python3
+
+# Install tree-sitter
+RUN git clone https://github.com/tree-sitter/tree-sitter
+RUN cd tree-sitter && git checkout tags/v0.22.6
+RUN make -C tree-sitter
+RUN make -C tree-sitter install
+
+# Download language parsers
+WORKDIR /tree-sitter-parsers
+RUN curl -o libtree-sitter-embedded-template.so -L "https://github.com/Faveod/tree-sitter-parsers/releases/download/v1.0.2/libtree-sitter-embedded-template-$(uname -m)-linux-gnu.so"
+RUN curl -o libtree-sitter-html.so              -L "https://github.com/Faveod/tree-sitter-parsers/releases/download/v1.0.2/libtree-sitter-html-$(uname -m)-linux-gnu.so"
+RUN curl -o libtree-sitter-javascript.so        -L "https://github.com/Faveod/tree-sitter-parsers/releases/download/v1.0.2/libtree-sitter-javascript-$(uname -m)-linux-gnu.so"
+RUN curl -o libtree-sitter-ruby.so              -L "https://github.com/Faveod/tree-sitter-parsers/releases/download/v1.0.2/libtree-sitter-ruby-$(uname -m)-linux-gnu.so"
+RUN curl -o libtree-sitter-php.so               -L "https://github.com/Faveod/tree-sitter-parsers/releases/download/v1.0.2/libtree-sitter-php-$(uname -m)-linux-gnu.so"
+RUN curl -o libtree-sitter-java.so              -L "https://github.com/Faveod/tree-sitter-parsers/releases/download/v1.0.2/libtree-sitter-java-$(uname -m)-linux-gnu.so"
+# RUN curl -o libtree-sitter-json.so              -L "https://github.com/Faveod/tree-sitter-parsers/releases/download/v1.0.2/libtree-sitter-json-$(uname -m)-linux-gnu.so"
+RUN curl -o libtree-sitter-python.so            -L "https://github.com/Faveod/tree-sitter-parsers/releases/download/v1.0.2/libtree-sitter-python-$(uname -m)-linux-gnu.so"
+
+# Reduce image size
+RUN rm -rf /var/cache/apk/*
+
+WORKDIR ${HOME}
+RUN rm -rf tree-sitter

--- a/docs/Maintaining.md
+++ b/docs/Maintaining.md
@@ -1,0 +1,25 @@
+# Maintaining
+
+## Release
+
+Make sure you make a PR to bump tree-sitter version if necessary, and the gem's
+version in `lib/tree_sitter/version.rb`.
+
+Once everything is merged, we'll have a draft release; edit it, removing all old
+artifacts (old version gems if they exist), assign a label corresponding to the
+new gem version, and release. This will automatically trigger the release
+workflow, making a github release and pushing all cross-compiled gems to
+[rubygems.org](https://rubygems.org/gems/ruby_tree_sitter).
+
+In the future, this will be far more simplified, and the maintainer will have to
+just launch a script locally.
+
+## Automatic tree-sitter version bump
+
+There's a schedueled workflow that checks for new releases of tree-sitter. Once
+we detect one, we will create a draft PR bumping the tree-sitter version. In
+order to integrate the PR, mark it as ready for review, removing its draft
+status, and then close and immediately reopen the PR to trigger the CI and
+cross-compile workflows.
+
+Unfortunately, this is the least complicated solution that works for now.


### PR DESCRIPTION
This will make it easier for us to frequently release new gems for new tree-sitter versions.

I will merge once the scheduled release passes. I tested on my local fork and it works.