### PR TITLE
Add custom errors

### DIFF
--- a/News.md
+++ b/News.md
@@ -2,6 +2,14 @@
 
 # [unreleaseed]
 
+- Add custom errors for language loading:
+  ```md
+  - LanguageLoadError
+  - ParserNotFoundError
+  - ParserVersionError
+  - SymbolNotFoundError
+  ```
+
 # v1.9.0 (21-11-2024)
 
 - Use tree-sitter v0.24.4.

--- a/News.md
+++ b/News.md
@@ -9,6 +9,7 @@
   - ParserVersionError
   - SymbolNotFoundError
   ```
+- Add custom `QueryCreationError` for query creation.
 
 # v1.9.0 (21-11-2024)
 

--- a/ext/tree_sitter/language.c
+++ b/ext/tree_sitter/language.c
@@ -42,7 +42,8 @@ static VALUE language_load(VALUE self, VALUE name, VALUE path) {
   void *lib = dlopen(path_cstr, RTLD_NOW);
   const char *err = dlerror();
   if (err != NULL) {
-    rb_raise(rb_eRuntimeError,
+    VALUE parser_not_found = rb_const_get(mTreeSitter, rb_intern("ParserNotFoundError"));
+    rb_raise(parser_not_found,
              "Could not load shared library `%s'.\nReason: %s", path_cstr, err);
   }
 
@@ -52,7 +53,8 @@ static VALUE language_load(VALUE self, VALUE name, VALUE path) {
   err = dlerror();
   if (err != NULL) {
     dlclose(lib);
-    rb_raise(rb_eRuntimeError,
+    VALUE symbol_not_found = rb_const_get(mTreeSitter, rb_intern("SymbolNotFoundError"));
+    rb_raise(symbol_not_found,
              "Could not load symbol `%s' from library `%s'.\nReason:%s",
              StringValueCStr(name), path_cstr, err);
   }
@@ -60,7 +62,8 @@ static VALUE language_load(VALUE self, VALUE name, VALUE path) {
   TSLanguage *lang = make_ts_language();
   if (lang == NULL) {
     dlclose(lib);
-    rb_raise(rb_eRuntimeError,
+    VALUE language_load_error = rb_const_get(mTreeSitter, rb_intern("LanguageLoadError"));
+    rb_raise(language_load_error,
              "TSLanguage = NULL for language `%s' in library `%s'.\nCall your "
              "local TSLanguage supplier.",
              StringValueCStr(name), path_cstr);
@@ -68,7 +71,8 @@ static VALUE language_load(VALUE self, VALUE name, VALUE path) {
 
   uint32_t version = ts_language_version(lang);
   if (version < TREE_SITTER_MIN_COMPATIBLE_LANGUAGE_VERSION) {
-    rb_raise(rb_eRuntimeError,
+    VALUE version_error = rb_const_get(mTreeSitter, rb_intern("ParserVersionError"));
+    rb_raise(version_error,
              "Language %s (v%d) from `%s' is old.\nMinimum supported ABI: "
              "v%d.\nCurrent ABI: v%d.",
              StringValueCStr(name), version, path_cstr,

--- a/ext/tree_sitter/query.c
+++ b/ext/tree_sitter/query.c
@@ -134,7 +134,8 @@ static VALUE query_initialize(VALUE self, VALUE language, VALUE source) {
   TSQuery *res = ts_query_new(lang, src, len, &error_offset, &error_type);
 
   if (res == NULL || error_offset > 0) {
-    rb_raise(rb_eRuntimeError, "Could not create query: TSQueryError%s",
+    VALUE query_creation_error = rb_const_get(mTreeSitter, rb_intern("QueryCreationError"));
+    rb_raise(query_creation_error, "Could not create query: TSQueryError%s",
              query_error_str(error_type));
   } else {
     SELF = res;

--- a/lib/tree_sitter.rb
+++ b/lib/tree_sitter.rb
@@ -13,6 +13,7 @@ require 'tree_sitter/version'
 
 require 'tree_sitter/mixins/language'
 
+require 'tree_sitter/error'
 require 'tree_sitter/node'
 require 'tree_sitter/query'
 require 'tree_sitter/query_captures'

--- a/lib/tree_sitter/error.rb
+++ b/lib/tree_sitter/error.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module TreeSitter
+  # Base tree-sitter error.
+  class TreeSitterError < StandardError
+  end
+
+  # Raised when the language symbol is found, but loading it returns nothing.
+  class LanguageLoadError < TreeSitterError
+  end
+
+  # Raised when a parser is not found.
+  class ParserNotFoundError < TreeSitterError
+  end
+
+  # Raised when the parser version is incompatible with the current tree-sitter.
+  class ParserVersionError < TreeSitterError
+  end
+
+  # Raised when a parser is not found.
+  class SymbolNotFoundError < TreeSitterError
+  end
+end

--- a/lib/tree_sitter/error.rb
+++ b/lib/tree_sitter/error.rb
@@ -5,6 +5,10 @@ module TreeSitter
   class TreeSitterError < StandardError
   end
 
+  # Raised when query creation fails.
+  class QueryCreationError < TreeSitterError
+  end
+
   # Raised when the language symbol is found, but loading it returns nothing.
   class LanguageLoadError < TreeSitterError
   end

--- a/lib/tree_sitter/mixins/language.rb
+++ b/lib/tree_sitter/mixins/language.rb
@@ -83,7 +83,7 @@ module TreeSitter
         lib = search_for_lib(name)
 
         if lib.nil?
-          raise <<~MSG.chomp
+          raise ::TreeSitter::ParserNotFoundError, <<~MSG.chomp
             Failed to load a parser for #{name}.
 
             #{search_lib_message}

--- a/test/tree_sitter/language_test.rb
+++ b/test/tree_sitter/language_test.rb
@@ -29,16 +29,21 @@ ruby_path =
   end
 
 describe 'language' do
+  it 'must raise a TreeSitter::ParserNotFoundError when a parser is not found' do
+    _ { TreeSitter.lang('rubyyyyyyyyyy') }.must_raise TreeSitter::ParserNotFoundError
+    _ { TreeSitter::Language.load('rubyyyyyyyyyy', ruby_path) }.must_raise TreeSitter::SymbolNotFoundError
+  end
+
   it 'must be able to load a library from `Pathname` (or any object that has `to_s`)' do
     _(TreeSitter::Language.load('ruby', ruby_path).field_count).must_be :positive?
   end
 
   it 'must throw an exception when the library is not found' do
-    _ { TreeSitter::Language.load('ruby', Pathname('tmp/none')) }.must_raise RuntimeError
+    _ { TreeSitter::Language.load('ruby', Pathname('tmp/none')) }.must_raise TreeSitter::ParserNotFoundError
   end
 
   it 'must throw an exception when the name is not correctly found' do
-    _ { TreeSitter::Language.load('nada', ruby_path) }.must_raise RuntimeError
+    _ { TreeSitter::Language.load('nada', ruby_path) }.must_raise TreeSitter::SymbolNotFoundError
   end
 
   it 'must return symbol count' do
@@ -66,7 +71,7 @@ describe 'language' do
   end
 
   it 'must return field symbol type' do
-    assert_equal TreeSitter::SymbolType::AUXILIARY, ruby.symbol_type(0)
+    assert_equal TreeSitter::SymbolType::REGULAR, ruby.symbol_type(1)
   end
 
   it 'must be of correct version' do

--- a/test/tree_sitter/query_test.rb
+++ b/test/tree_sitter/query_test.rb
@@ -26,6 +26,10 @@ combined = "#{pattern} #{capture}"
 # NOTE: It' still unclear to me what a captured string is.
 
 describe 'pattern/capture/string' do
+  it 'must raise an exception when query creation fails' do
+    _ { TreeSitter::Query.new(ruby, '(stupid query') }.must_raise TreeSitter::QueryCreationError
+  end
+
   it 'must return an Integer for pattern count' do
     query = TreeSitter::Query.new(ruby, pattern)
     assert_equal 1, query.pattern_count


### PR DESCRIPTION
Raising `RuntimeError` on its own, everywhere, was not a good idea, but it was handy when I was learning how to write extensions, and I wanted to move as fast as possible.

All the added errors are now `< TreeSitterError < StandardError`, which gives the user more control on what to catch, when, and what to do when encountered.