### PR TITLE
Make TreeSitterError inherit Exception

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,6 +30,9 @@ Lint/EmptyBlock:
     - test/**/*
     - Rakefile
 
+Lint/InheritException:
+  Enabled: false
+
 Metrics/AbcSize:
   Max: 29
 

--- a/News.md
+++ b/News.md
@@ -2,6 +2,9 @@
 
 # [unreleaseed]
 
+- Make `TreeSitter::TreeSitterError < Exception` instead of `StandardErorr`;
+  we don't want them to be handled by default `rescue`.
+
 # v1.9.1 (05-12-2024)
 
 - Add custom errors for language loading:

--- a/News.md
+++ b/News.md
@@ -2,6 +2,8 @@
 
 # [unreleaseed]
 
+# v1.10.0 (10-12-2024)
+
 - Make `TreeSitter::TreeSitterError < Exception` instead of `StandardErorr`;
   we don't want them to be handled by default `rescue`.
 

--- a/lib/tree_sitter/error.rb
+++ b/lib/tree_sitter/error.rb
@@ -2,7 +2,7 @@
 
 module TreeSitter
   # Base tree-sitter error.
-  class TreeSitterError < StandardError
+  class TreeSitterError < Exception
   end
 
   # Raised when query creation fails.

--- a/lib/tree_sitter/version.rb
+++ b/lib/tree_sitter/version.rb
@@ -4,5 +4,5 @@ module TreeSitter
   # The version of the tree-sitter library.
   TREESITTER_VERSION = '0.24.4'
   # The current version of the gem.
-  VERSION = '1.9.1'
+  VERSION = '1.10.0'
 end


### PR DESCRIPTION
We don't want our exceptions to go unnoticed or handled by default `rescue`.

Consumers need to handle them explicitly.