### PR TITLE
FIx cross-compiled for Ruby 3.3 & Bump v1.11.1

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -43,6 +43,7 @@ gem-native:
 
 [group('gem')]
 gem-cross:
+  rm -rf Gemfile.lock
   bundle exec rake gem:cross
 
 [group('gem')]

--- a/News.md
+++ b/News.md
@@ -2,6 +2,12 @@
 
 # [unreleaseed]
 
+# v1.11.1 (02-01-2025)
+
+- Fix:
+  - precompiled gem problem with ruby 3.3. See [rake-compiler-dock](https://github.com/rake-compiler/rake-compiler-dock/blob/3811c31917a9dcb9cb139c0841f420c82663ae89/History.md?plain=1#L35)
+  - tree-sitter version: we declared v0.24.6, but we were on v0.24.5!
+
 # v1.11.0 (02-01-2025)
 
 - Use tree-sitter v0.24.6.

--- a/Rakefile
+++ b/Rakefile
@@ -23,7 +23,11 @@ PLATFORMS = %w[
   x86_64-linux-musl
 ].freeze
 
-CROSS_RUBIES = %w[3.4.0 3.3.0 3.2.0 3.1.0 3.0.0].freeze
+# The only exception in the version scheme is ruby 3.3.5 because of an issue
+# with ruby cross compilation.
+#
+# See https://github.com/rake-compiler/rake-compiler-dock/blob/3811c31917a9dcb9cb139c0841f420c82663ae89/History.md?plain=1#L35C117-L35C156
+CROSS_RUBIES = %w[3.4.0 3.3.5 3.2.0 3.1.0 3.0.0].freeze
 
 ENV['RUBY_CC_VERSION'] = CROSS_RUBIES.join(':') if !ENV['RUBY_CC_VERSION']
 

--- a/lib/tree_sitter/version.rb
+++ b/lib/tree_sitter/version.rb
@@ -2,7 +2,7 @@
 
 module TreeSitter
   # The version of the tree-sitter library.
-  TREESITTER_VERSION = '0.24.5'
+  TREESITTER_VERSION = '0.24.6'
   # The current version of the gem.
-  VERSION = '1.11.0'
+  VERSION = '1.11.1'
 end


### PR DESCRIPTION
Rake-compiler-dock just silently removed support for `3.3.0` in the version strings, instead of exploding.
See [here](https://github.com/rake-compiler/rake-compiler-dock/blob/3811c31917a9dcb9cb139c0841f420c82663ae89/History.md?plain=1#L35).