### PR TITLE
Add Ruby 4.0 cross-compilation support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ group :development, :test do
   gem 'ostruct'
   gem 'rake', '~> 13.2'
   gem 'rake-compiler', '~> 1.2'
-  gem 'rake-compiler-dock', '~> 1.5'
+  gem 'rake-compiler-dock', '~> 1.11'
   gem 'rubocop'
   gem 'ruby-lsp', '~> 0.17', require: false
   gem 'ruby_memcheck', '~> 1.3'

--- a/Rakefile
+++ b/Rakefile
@@ -24,7 +24,7 @@ PLATFORMS = %w[
   x86_64-linux-musl
 ].freeze
 
-ENV['RUBY_CC_VERSION'] = RakeCompilerDock.ruby_cc_version('~> 3.1')
+ENV['RUBY_CC_VERSION'] = RakeCompilerDock.ruby_cc_version('~> 3.1', '~> 4.0')
 
 gemspec = Gem::Specification.load('tree_sitter.gemspec')
 

--- a/test/tree_sitter/query_test.rb
+++ b/test/tree_sitter/query_test.rb
@@ -218,7 +218,7 @@ describe 'matches' do
     matches.each do |m|
       _(m).must_be_kind_of Hash
       _(m.keys.sort).must_equal %w[product product.left product.right sum sum.left]
-      _(m.values.all? { |n| n.instance_of?(TreeSitter::Node) }).must_be_equal true
+      _(m.values.all?(TreeSitter::Node)).must_be_equal true
     end
   end
 end


### PR DESCRIPTION
Precompiled platform gems (e.g. `x86_64-linux-gnu`) currently set `required_ruby_version` to `>= 3.1, < 3.5.dev`,
  making them incompatible with Ruby 4.0. This is because:

  1. `rake-compiler-dock ~> 1.5` doesn't include Ruby 4.0 cross-compilation toolchains
  2. `ruby_cc_version('~> 3.1')` excludes Ruby 4.0 (`~>` means `< 4.0`)

  ### Changes

  - **Gemfile**: bump `rake-compiler-dock` to `~> 1.11` (v1.11.0 added Ruby 4.0.0 support)
  - **Rakefile**: add `'~> 4.0'` to `ruby_cc_version` so Ruby 4.0 is included in cross-compilation targets
  
  
  Fixes https://github.com/Faveod/ruby-tree-sitter/issues/103